### PR TITLE
TH-188 | Add a canonical url into the page meta

### DIFF
--- a/src/server/Html.tsx
+++ b/src/server/Html.tsx
@@ -13,11 +13,21 @@ interface Props {
     title: {
       toComponent: () => void;
     };
+    link: {
+      toComponent: () => void;
+    };
   };
   state: object;
+  canonicalUrl: string;
 }
 
-const Html: React.FC<Props> = ({ assets, content, helmet, state }) => {
+const Html: React.FC<Props> = ({
+  assets,
+  content,
+  helmet,
+  state,
+  canonicalUrl
+}) => {
   return (
     <html lang="en">
       <head>
@@ -27,10 +37,13 @@ const Html: React.FC<Props> = ({ assets, content, helmet, state }) => {
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
         <meta name="theme-color" content="#000000" />
+        <meta property="og:url" content={canonicalUrl} />
         <link rel="manifest" href="/manifest.json" />
         <link rel="shortcut icon" href="/favicon.ico" />
+        <link rel="canonical" href={canonicalUrl} />
         {helmet.meta.toComponent()}
         {helmet.title.toComponent()}
+        {helmet.link.toComponent()}
         {assets.css &&
           assets.css.map((c: string, idx: number) => (
             <link key={idx} href={c} rel="stylesheet" />

--- a/src/server/__tests__/Html.test.tsx
+++ b/src/server/__tests__/Html.test.tsx
@@ -9,8 +9,12 @@ test("Html matches snapshot", () => {
     js: ["test1.js", "test2.js"]
   };
   const content = "<p>Test content</p>";
+  const canonicalUrl = "http://localhost:3000";
   // Helmet.renderStatic() is not available on client side so use mock data to test
   const helmet = {
+    link: {
+      toComponent: () => `<link rel="canonical" href="${canonicalUrl}" />`
+    },
     meta: {
       toComponent: () =>
         '<meta data-react-helmet="true" name="description" content="testing react helmet">'
@@ -21,7 +25,13 @@ test("Html matches snapshot", () => {
   };
 
   const component = renderer.create(
-    <Html assets={assets} content={content} helmet={helmet} state={{}} />
+    <Html
+      assets={assets}
+      content={content}
+      helmet={helmet}
+      state={{}}
+      canonicalUrl={canonicalUrl}
+    />
   );
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/src/server/__tests__/__snapshots__/Html.test.tsx.snap
+++ b/src/server/__tests__/__snapshots__/Html.test.tsx.snap
@@ -16,6 +16,10 @@ exports[`Html matches snapshot 1`] = `
       content="#000000"
       name="theme-color"
     />
+    <meta
+      content="http://localhost:3000"
+      property="og:url"
+    />
     <link
       href="/manifest.json"
       rel="manifest"
@@ -24,8 +28,13 @@ exports[`Html matches snapshot 1`] = `
       href="/favicon.ico"
       rel="shortcut icon"
     />
+    <link
+      href="http://localhost:3000"
+      rel="canonical"
+    />
     &lt;meta data-react-helmet="true" name="description" content="testing react helmet"&gt;
     &lt;title&gt;Test title&lt;/title&gt;
+    &lt;link rel="canonical" href="http://localhost:3000" /&gt;
     <link
       href="test1.css"
       rel="stylesheet"

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,6 +9,7 @@ import { getDataFromTree } from "react-apollo";
 import ReactDOMServer from "react-dom/server";
 import Helmet from "react-helmet";
 
+import getDomainFromRequest from "../util/getDomainFromRequest";
 import { getAssets } from "./assets";
 import Html from "./Html";
 import ServerApp from "./ServerApp";
@@ -61,12 +62,18 @@ app.use(async (req: Request, res: Response) => {
   // Executes all graphql queries for the current state of application
   await getDataFromTree(el);
 
-  // // Extracts apollo client cache
+  // Extracts apollo client cache
   const state = client.extract();
   const content = ReactDOMServer.renderToString(el);
   const helmet = Helmet.renderStatic();
   const assets = getAssets();
-  const htmlEl = React.createElement(Html, { assets, content, helmet, state });
+  const htmlEl = React.createElement(Html, {
+    assets,
+    canonicalUrl: `${getDomainFromRequest(req)}${req.url}`,
+    content,
+    helmet,
+    state
+  });
   const html = ReactDOMServer.renderToString(htmlEl);
 
   if (context.url) {

--- a/src/util/getDomainFromRequest.ts
+++ b/src/util/getDomainFromRequest.ts
@@ -1,0 +1,9 @@
+import { Request } from "express";
+
+/** Get domain name from express request */
+export default (req: Request): string => {
+  // This will return the host as well as the possible port
+  const host = req.get("Host");
+
+  return `${req.protocol}://${host}`;
+};


### PR DESCRIPTION
In order to provide a proper url property for open graph, i.e.
Facebook, we must use the original request as the source. This makes
it easy to apply this meta information on the server side.

In order to complete TH-178, we only need this meta information on the
events page, but with this commit we are applying it to all responses.

I've also applied more generic canonical url link, which is used by
search engines.

--------

https://helsinkisolutionoffice.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=TH-188

I had some trouble getting a good vision of how the canonical url should be managed. As far as I understand, with a SSR setup, we have to use the request express provides to get a complete url. This makes it rather straight forward to apply this meta information on the server side.

The implementation sort of touches things out of its scope--it applies the changes on all the responses. But this is not likely an issue as the meta information we are adding should be correct for all the responses and is generic enough where most pages likely benefit from having it.

Another route, as an example, would be to pass this information onto the client side where could pass it around based on our own choosing. In that case we could apply the meta information only on the pages we would like. We could also apply the meta information in a single place in the codebase which could make it easier for developers to understand if all the required properties are present. The downside is that we end up creating orchestration around a non-conventional abstraction.

