### PR TITLE
Add meta information for social media sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ Run linter to all the files in app
 Fix all the linter errors
 
 ## Debugging
+
 ### Debugging project in VS Code
 
 To debug in VS Code:
+
 1. Install the "Debugger for Chrome" extension to VS Code
 2. Run `yarn start`
 3. Set a breakpoint
@@ -88,8 +90,71 @@ We recommend using VS Code's debugger.
 See more detailed instructions here:
 https://create-react-app.dev/docs/debugging-tests#debugging-tests-in-chrome
 
+## Notes about social media sharing
+
+The app includes controls that can be used to share pages on social media. In essence, these are integrations to different social media platforms. In this section of the readme, we will go over how these integrations are expected to behave and what logic was used when applying the metadata.
+
+### Server Side Rendering and scraping
+
+Social media platforms rely on scrapers to find metadata they can use to enrich links which are shared on their platform. It's beneficial to conform to these metadata requirements, because they allow for the shared content to be displayed in a way that is more engaging.
+
+To our reprieve, server side rendering means that we can offer the correct content for the scrapers with relative ease. If you set tags from within the client code with `react-helmet`, the changes should be visible to scrapers as long as they are part of the content that gets rendered when a page is first accessed.
+
+However, you have to keep in mind that scraping will only work when you are making use of server side rendering. With client side rendering, the meta tags won't be available during first the response. This makes developing, testing and debugging more cumbersome for these features.
+
+### Canonical url
+
+Because of SSR, we can't rely on client side information about current the current path. Instead, we have to use properties found from the request object of Express on the server side.
+
+For now, canonical urls are applied for all pages on the server side of the code.
+
+### Commonly used metadata and the expectations platforms have form them
+
+Facebook is the original entity behind the Open Graph initiative and makes use of it for its sharing API. Although Twitter provides its own dialect for declaring metadata, it can also read Open Graph tags. LinkedIn also relies on Open Graph tags.
+
+That's why the three most important tags are `og:title`, `og:description` and `og:image`. On top of these Facebook requires `og:url` whereas Twitter strongly recommends `twitter:card`.
+
+When applying Open Graph tags, be mindful of using `property` instead of `name`.
+
+```jsx
+<meta property="og:title" content="Lorem ipsum..." />
+```
+
+**`og:title`**
+
+`Facebook`: The title of your article without any branding such as your site name. <sup>[1]</sup>
+`Twitter`: Title of content (max 70 characters) <sup>[2]</sup>  
+`LinkedIn`: Title of the article <sup>[3]</sup>
+
+**`og:description`**
+
+`Facebook`: A brief description of the content, usually between 2 and 4 sentences. This will displayed below the title of the post on Facebook. <sup>[1]</sup>  
+`Twitter`: Description of content (maximum 200 characters) <sup>[2]</sup>  
+`LinkedIn`: Description that will show in the preview <sup>[3]</sup>. Minimum of 100 characters according to debugger.
+
+**`og:image`**
+
+`Facebook`: Facebook: The minimum allowed image dimension is 200 x 200 pixels, the size of the image file must not exceed 8 MB, use images that are at least 1200 x 630 pixels for the best display on high resolution devices. At the minimum, you should use images that are 600 x 315 pixels to display link page posts with larger images. <sup>[1]</sup>  
+`Twitter`: (For a summary card) A URL to a unique image representing the content of the page. You should not use a generic image such as your website logo, author photo, or other image that spans multiple pages. Images for this Card support an aspect ratio of 1:1 with minimum dimensions of 144x144 or maximum of 4096x4096 pixels. Images must be less than 5MB in size. The image will be cropped to a square on all platforms. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported. <sup>[2]</sup>  
+`LinkedIn`: Max file size: 5 MB, Minimum image dimensions: 1200 (w) x 627 (h) pixels, Recommended ratio: 1.91:1. <sup>[3]</sup>
+
+### Explanations for platform specific metadata
+
+**`twitter:card`**: (Twitter) The card type, which will be one of “summary”, “summary_large_image”, “app”, or “player”. <sup>[4]</sup>
+
+**`og:url`**: (Facebook) The canonical URL for your page. This should be the undecorated URL, without session variables, user identifying parameters, or counters. Likes and Shares for this URL will aggregate at this URL. For example, mobile domain URLs should point to the desktop version of the URL as the canonical URL to aggregate Likes and Shares across different versions of the page. <sup>[1]</sup>
+
+**`fb:app_id`**: (Facebook) In order to use Facebook Insights you must add the app ID to your page. Insights lets you view analytics for traffic to your site from Facebook. Find the app ID in your App Dashboard. <sup>[1]</sup> _We do not need to include the app ID in the meta information for sharing to work. We need to pass it when we want to share from within our application. If we apply it in the metadata, Facebook is able to provide better metrics about sharing in our application._
+
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+---
+
+[1] https://developers.facebook.com/docs/sharing/webmasters/#markup  
+[2] https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup  
+[3] https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin?lang=en  
+[4] https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "@graphql-codegen/typescript": "1.9.1",
     "@graphql-codegen/typescript-operations": "1.9.1",
     "@graphql-codegen/typescript-react-apollo": "1.9.1",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.4.0",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <meta
       name="description"
       content="Web site created using create-react-app"
+      data-react-helmet="true"
     />
     <link rel="apple-touch-icon" href="logo192.png" />
     <!--

--- a/src/domain/event/EventPageContainer.tsx
+++ b/src/domain/event/EventPageContainer.tsx
@@ -10,12 +10,13 @@ import EventClosedHero from "./EventClosedHero";
 import EventContent from "./EventContent";
 import EventHero from "./EventHero";
 import styles from "./eventPage.module.scss";
+import EventPageMeta from "./EventPageMeta";
 import { isEventClosed } from "./EventUtils";
 import SimilarEvents from "./SimilarEvents";
 
-const EventPageContainer: React.FC<
-  RouteComponentProps<{ id: string }>
-> = props => {
+const EventPageContainer: React.FC<RouteComponentProps<{
+  id: string;
+}>> = props => {
   const { pathname } = useLocation();
   const eventId = props.match.params.id;
   const { data: eventData, loading } = useEventDetailsQuery({
@@ -37,6 +38,8 @@ const EventPageContainer: React.FC<
         <LoadingSpinner isLoading={loading}>
           {eventData && (
             <>
+              {/* Wait for data to be accessible before updating metadata */}
+              <EventPageMeta eventData={eventData} />
               {!!eventClosed ? (
                 <EventClosedHero />
               ) : (

--- a/src/domain/event/EventPageMeta.tsx
+++ b/src/domain/event/EventPageMeta.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+
+import { EventDetailsQuery, LocalizedObject } from "../../generated/graphql";
+import getLocale from "../../util/getLocale";
+import getLocalisedString from "../../util/getLocalisedString";
+
+interface Props {
+  eventData: EventDetailsQuery;
+}
+
+const EventPageMeta: React.FC<Props> = ({ eventData }) => {
+  const locale = getLocale();
+
+  const getLocal = (localizedObject: LocalizedObject) =>
+    getLocalisedString(localizedObject, locale);
+
+  const name = getLocal(eventData.eventDetails.name);
+  const description = getLocal(eventData.eventDetails.description || {});
+  const image = eventData.eventDetails.images.length
+    ? eventData.eventDetails.images[0].url
+    : null;
+
+  const openGraphProperties: { [key: string]: string } = {
+    description: description,
+    image: image || "",
+    title: name
+  };
+
+  return (
+    <Helmet>
+      <title>{name}</title>
+      <meta name="description" content={description} />
+      <meta name="twitter:card" content="summary" />
+      {Object.entries(openGraphProperties).map(([property, value]) => (
+        <meta key={property} property={`og:${property}`} content={value} />
+      ))}
+    </Helmet>
+  );
+};
+
+export default EventPageMeta;

--- a/src/domain/event/__tests__/EventPageMeta.test.jsx
+++ b/src/domain/event/__tests__/EventPageMeta.test.jsx
@@ -1,0 +1,65 @@
+import { render, waitForDomChange } from "@testing-library/react";
+import React from "react";
+
+import EventPageMeta from "../EventPageMeta";
+
+const getWrapper = props => render(<EventPageMeta {...props} />);
+
+// Rendering EventPageMeta creates a side effect--the document head will be
+// mutated. This mutation will persist between tests. This can be problematic:
+// (1) other test suites asserting against `document.head` may receive
+//     unexpected initial conditions
+// (2) this test suite may receive unexpected initial conditions if
+//     `EventPageMeta` is rendered as part of some other test suite (likely)
+// To combat these conditions, we are manually managing the `head` in setup and
+// teardown.
+let initialHeadInnerHTML = null;
+
+beforeEach(() => {
+  const head = document.querySelector("head");
+  initialHeadInnerHTML = head.innerHTML;
+
+  document.head.innerHTML = "";
+});
+
+afterEach(() => {
+  document.head.innerHTML = initialHeadInnerHTML;
+});
+
+test("applies expected metadata", async () => {
+  const eventName = "Name of event";
+  const eventDescription = "Description for event";
+  const eventImage = "https://localhost/example/path";
+  const mockEventData = {
+    eventDetails: {
+      description: {
+        fi: eventDescription
+      },
+      images: [{ url: eventImage }],
+      name: {
+        fi: eventName
+      }
+    }
+  };
+
+  // This function is usually used for the helpers it returns. However, the
+  // scope f the helpers is limited to `body`. As we need to assert against
+  // the content of the `head`, we have to make queries without helpers. We are
+  // using testing library to render for consistency.
+  getWrapper({ eventData: mockEventData });
+
+  await waitForDomChange();
+
+  const title = document.title;
+  const head = document.querySelector("head");
+  const metaDescription = head.querySelector('[name="description"]');
+  const ogTitle = head.querySelector('[property="og:title"]');
+  const ogDescription = head.querySelector('[property="og:description"]');
+  const ogImage = head.querySelector('[property="og:image"]');
+
+  expect(title).toEqual(eventName);
+  expect(metaDescription).toHaveAttribute("content", eventDescription);
+  expect(ogTitle).toHaveAttribute("content", eventName);
+  expect(ogDescription).toHaveAttribute("content", eventDescription);
+  expect(ogImage).toHaveAttribute("content", eventImage);
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,5 @@
 import "./common/test/test18nInit";
+import "@testing-library/jest-dom/extend-expect";
 
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,6 +1278,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.1", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.6":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.0.tgz#8c81711517c56b3d00c6de706b0fb13dc3531549"
+  integrity sha512-Z7ti+HB0puCcLmFE3x90kzaVgbx6TRrYIReaygW6EkBEnJh1ajS4/inhF7CypzWeDV3NFl1AfWj0eMtdihojxw==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.4.tgz#b23a856751e4bf099262f867767889c0e3fe175b"
@@ -1928,6 +1935,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -2030,6 +2042,42 @@
     "@svgr/plugin-jsx" "^4.3.2"
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
+
+"@testing-library/dom@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.11.0.tgz#962a38f1a721fdb7c9e35e7579e33ff13a00eda4"
+  integrity sha512-Pkx9LMIGshyNbfmecjt18rrAp/ayMqGH674jYER0SXj0iG9xZc+zWRjk2Pg9JgPBDvwI//xGrI/oOQkAi4YEew==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    "@types/testing-library__dom" "^6.0.0"
+    aria-query "3.0.0"
+    pretty-format "^24.9.0"
+    wait-for-expect "^3.0.0"
+
+"@testing-library/jest-dom@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
+  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+  dependencies:
+    "@babel/runtime" "^7.5.1"
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^3.0.0"
+
+"@testing-library/react@^9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.4.0.tgz#b021ac8cb987c8dc54c6841875f745bf9b2e88e5"
+  integrity sha512-XdhDWkI4GktUPsz0AYyeQ8M9qS/JFie06kcSnUVcpgOwFjAu9vhwR83qBl+lw9yZWkbECjL8Hd+n5hH6C0oWqg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+    "@testing-library/dom" "^6.11.0"
+    "@types/testing-library__react" "^9.1.2"
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -2397,6 +2445,21 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/testing-library__dom@*", "@types/testing-library__dom@^6.0.0":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.11.1.tgz#6058a6ac391db679f7c60dbb27b81f0620de2dd9"
+  integrity sha512-ImChHtQqmjwraRLqBC2sgSQFtczeFvBmBcfhTYZn/3KwXbyD07LQykEQ0xJo7QHc1GbVvf7pRyGaIe6PkCdxEw==
+  dependencies:
+    pretty-format "^24.3.0"
+
+"@types/testing-library__react@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.2.tgz#e33af9124c60a010fc03a34eff8f8a34a75c4351"
+  integrity sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==
+  dependencies:
+    "@types/react-dom" "*"
+    "@types/testing-library__dom" "*"
 
 "@types/valid-url@1.0.2":
   version "1.0.2"
@@ -2962,7 +3025,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^3.0.0:
+aria-query@3.0.0, aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
@@ -4539,7 +4602,12 @@ css-what@2.1, css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css@^2.0.0:
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.0.0, css@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -7659,7 +7727,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.9.0:
+jest-diff@^24.0.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -7773,7 +7841,7 @@ jest-leak-detector@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-matcher-utils@^24.9.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
   integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
@@ -8788,6 +8856,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
 
 mini-create-react-context@^0.3.0:
   version "0.3.2"
@@ -10610,7 +10683,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -11270,6 +11343,14 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -12473,6 +12554,13 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 strip-json-comments@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
@@ -13169,6 +13257,11 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+wait-for-expect@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.1.tgz#ec204a76b0038f17711e575720aaf28505ac7185"
+  integrity sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
Facebook, Twitter and LinkedIn have been taken into account. Adds a
section into readme that covers requirements for metadata.

I also added a new dependecy in @testing-library/react. At the time of
this commit, it was recommended  by create-react-application.

ref: TH-184