### PR TITLE
Fix missing location icon

### DIFF
--- a/src/common/components/search/AutosuggestMenu.tsx
+++ b/src/common/components/search/AutosuggestMenu.tsx
@@ -50,7 +50,7 @@ const AutosuggestMenu: FunctionComponent<Props> = ({
             >
               <div className={styles.colorIndicator} />
               <div className={styles.icon}>
-                {item.type === "area" && <IconLocation />}
+                {item.type === "district" && <IconLocation />}
               </div>
               <div className={styles.textWrapper}>
                 <button onClick={handleClick}>


### PR DESCRIPTION
In this 3b6cb637f81d6e4f187d17cb1cfd9cef18b0298f commit, I used the old type for applying the location icon.