### PR TITLE
TH-214 | Hide past event 

### DIFF
--- a/src/common/components/dateSelector/DateRangeInputs.tsx
+++ b/src/common/components/dateSelector/DateRangeInputs.tsx
@@ -1,3 +1,4 @@
+import { isPast } from "date-fns";
 import React, { ChangeEvent, MutableRefObject } from "react";
 
 import IconCalendarAdd from "../../../icons/IconCalendarAdd";
@@ -47,9 +48,12 @@ class DateRangeInputs extends React.Component<Props> {
       startDateRaw,
       startDateRef
     } = this.props;
-    const newDate = convertFinnishDateStrToDate(startDateRaw);
+    let newDate = convertFinnishDateStrToDate(startDateRaw);
 
     if (newDate) {
+      if (isPast(newDate)) {
+        newDate = startDate;
+      }
       if (startDateRef) {
         onBlurInput(startDateRef, newDate);
       }
@@ -68,9 +72,12 @@ class DateRangeInputs extends React.Component<Props> {
       onBlurInput,
       setEndDateRaw
     } = this.props;
-    const newDate = convertFinnishDateStrToDate(endDateRaw);
+    let newDate = convertFinnishDateStrToDate(endDateRaw);
 
     if (newDate) {
+      if (isPast(newDate)) {
+        newDate = endDate;
+      }
       if (endDateRef) {
         onBlurInput(endDateRef, newDate);
       }

--- a/src/common/components/dateSelector/DateRangePicker.tsx
+++ b/src/common/components/dateSelector/DateRangePicker.tsx
@@ -70,6 +70,7 @@ const DateRangePicker: FunctionComponent<Props> = ({
     <DatePicker
       ref={datePicker}
       locale={locale}
+      minDate={new Date()}
       inlineFocusSelectedMonth={false}
       selectsStart={true}
       selectsEnd={true}

--- a/src/common/components/dateSelector/DateSelectorMenu.tsx
+++ b/src/common/components/dateSelector/DateSelectorMenu.tsx
@@ -57,14 +57,6 @@ const DateSelectorMenu: FunctionComponent<Props> = ({
       {!isCustomDate && (
         <div className={styles.wrapper}>
           <Checkbox
-            checked={dateTypes.indexOf(DATE_TYPES.ALL) !== -1}
-            name="date"
-            onChange={handleCheckboxChange}
-            value={DATE_TYPES.ALL}
-          >
-            {formatMessage("commons.dateSelector.dateTypeAll")}
-          </Checkbox>
-          <Checkbox
             checked={dateTypes.indexOf(DATE_TYPES.TODAY) !== -1}
             name="date"
             onChange={handleCheckboxChange}

--- a/src/common/components/dateSelector/DateSelectorMenu.tsx
+++ b/src/common/components/dateSelector/DateSelectorMenu.tsx
@@ -65,7 +65,7 @@ const DateSelectorMenu: FunctionComponent<Props> = ({
             {formatMessage("commons.dateSelector.dateTypeToday")}
           </Checkbox>
           <Checkbox
-            checked={dateTypes.indexOf(DATE_TYPES.TOMORROW) !== -1}
+            checked={dateTypes.includes(DATE_TYPES.TOMORROW)}
             name="date"
             onChange={handleCheckboxChange}
             value={DATE_TYPES.TOMORROW}
@@ -73,7 +73,7 @@ const DateSelectorMenu: FunctionComponent<Props> = ({
             {formatMessage("commons.dateSelector.dateTypeTomorrow")}
           </Checkbox>
           <Checkbox
-            checked={dateTypes.indexOf(DATE_TYPES.THIS_WEEK) !== -1}
+            checked={dateTypes.includes(DATE_TYPES.THIS_WEEK)}
             name="date"
             onChange={handleCheckboxChange}
             value={DATE_TYPES.THIS_WEEK}
@@ -81,7 +81,7 @@ const DateSelectorMenu: FunctionComponent<Props> = ({
             {formatMessage("commons.dateSelector.dateTypeThisWeek")}
           </Checkbox>
           <Checkbox
-            checked={dateTypes.indexOf(DATE_TYPES.WEEKEND) !== -1}
+            checked={dateTypes.includes(DATE_TYPES.WEEKEND)}
             name="date"
             onChange={handleCheckboxChange}
             value={DATE_TYPES.WEEKEND}

--- a/src/common/components/dateSelector/__tests__/__snapshots__/DateSelectorMenu.test.tsx.snap
+++ b/src/common/components/dateSelector/__tests__/__snapshots__/DateSelectorMenu.test.tsx.snap
@@ -15,21 +15,6 @@ exports[`DateSelectorMenu matches snapshot 1`] = `
         name="date"
         onChange={[Function]}
         type="checkbox"
-        value="all"
-      />
-      <span
-        className="checkmark"
-      />
-      Koska tahansa
-    </label>
-    <label
-      className="checkbox"
-    >
-      <input
-        checked={false}
-        name="date"
-        onChange={[Function]}
-        type="checkbox"
         value="today"
       />
       <span

--- a/src/common/components/dateSelector/datePicker.scss
+++ b/src/common/components/dateSelector/datePicker.scss
@@ -105,5 +105,10 @@
       color: $hel-white;
       background-color: $hel-bus;
     }
+
+    &--disabled {
+      color: $hel-black-40;
+      background-color: $hel-white;
+    }
   }
 }

--- a/src/domain/event/SimilarEvents.tsx
+++ b/src/domain/event/SimilarEvents.tsx
@@ -7,7 +7,7 @@ import { EventDetailsQuery, useEventListQuery } from "../../generated/graphql";
 import isClient from "../../util/isClient";
 import { getSearchQuery } from "../../util/searchUtils";
 // Use same page size as on event search page
-import { PAGE_SIZE } from "../eventSearch/constants";
+import { EVENT_SORT_OPTIONS, PAGE_SIZE } from "../eventSearch/constants";
 import { getEventFilters } from "../eventSearch/EventListUtils";
 import { SIMILAR_EVENTS_AMOUNT } from "./constants";
 import SimilarEventCard from "./SimilarEventCard";
@@ -39,7 +39,11 @@ const SimilarEvents: React.FC<Props> = ({ eventData }) => {
 
   const { data: eventsData, loading } = useEventListQuery({
     skip: !isClient,
-    variables: getEventFilters(searchParams, PAGE_SIZE)
+    variables: getEventFilters(
+      searchParams,
+      PAGE_SIZE,
+      EVENT_SORT_OPTIONS.END_TIME
+    )
   });
 
   // To display only certain amount of events.

--- a/src/domain/eventSearch/EventListUtils.ts
+++ b/src/domain/eventSearch/EventListUtils.ts
@@ -9,6 +9,7 @@ import {
 import { EventListQuery } from "../../generated/graphql";
 import { formatDate } from "../../util/dateUtils";
 import getUrlParamAsString from "../../util/getUrlParamAsString";
+import { EVENT_SORT_OPTIONS } from "./constants";
 
 /**
  * Get start and end dates to event list filtering
@@ -67,7 +68,11 @@ const getFilterDates = (
  * @param pageSize {number}
  * @return {object}
  */
-export const getEventFilters = (params: URLSearchParams, pageSize: number) => {
+export const getEventFilters = (
+  params: URLSearchParams,
+  pageSize: number,
+  sortOrder: EVENT_SORT_OPTIONS
+) => {
   const dateTypes = getUrlParamAsString(params, "dateTypes");
   let { startDate, endDate } = getFilterDates(
     dateTypes,
@@ -150,6 +155,7 @@ export const getEventFilters = (params: URLSearchParams, pageSize: number) => {
     locations: places,
     pageSize,
     publisher: params.get("publisher"),
+    sort: sortOrder,
     startDate: startDate,
     text: params.get("search")
   };

--- a/src/domain/eventSearch/EventListUtils.ts
+++ b/src/domain/eventSearch/EventListUtils.ts
@@ -1,4 +1,4 @@
-import { addDays, endOfWeek, startOfWeek, subDays } from "date-fns";
+import { addDays, endOfWeek, isPast, startOfWeek, subDays } from "date-fns";
 
 import {
   CATEGORIES,
@@ -69,11 +69,18 @@ const getFilterDates = (
  */
 export const getEventFilters = (params: URLSearchParams, pageSize: number) => {
   const dateTypes = getUrlParamAsString(params, "dateTypes");
-  const { startDate, endDate } = getFilterDates(
+  let { startDate, endDate } = getFilterDates(
     dateTypes,
     params.get("startDate"),
     params.get("endDate")
   );
+  if (!startDate || isPast(new Date(startDate))) {
+    startDate = formatDate(new Date());
+  }
+  if (endDate && isPast(new Date(endDate))) {
+    endDate = formatDate(new Date());
+  }
+
   const places = getUrlParamAsString(params, "places");
 
   const categories = getUrlParamAsString(params, "categories");

--- a/src/domain/eventSearch/EventSearchPageContainer.tsx
+++ b/src/domain/eventSearch/EventSearchPageContainer.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps, useLocation, withRouter } from "react-router";
 import LoadingSpinner from "../../common/components/spinner/LoadingSpinner";
 import { useEventListQuery } from "../../generated/graphql";
 import Layout from "../app/layout/Layout";
-import { PAGE_SIZE } from "./constants";
+import { EVENT_SORT_OPTIONS, PAGE_SIZE } from "./constants";
 import { getEventFilters, getNextPage } from "./EventListUtils";
 import styles from "./eventSearchPage.module.scss";
 import Search from "./Search";
@@ -18,7 +18,11 @@ const EventSearchPageContainer: React.FC<RouteComponentProps> = () => {
   const { data: eventsData, fetchMore, loading } = useEventListQuery({
     notifyOnNetworkStatusChange: true,
     ssr: false,
-    variables: getEventFilters(searchParams, PAGE_SIZE)
+    variables: getEventFilters(
+      searchParams,
+      PAGE_SIZE,
+      EVENT_SORT_OPTIONS.END_TIME
+    )
   });
 
   const handleLoadMore = async () => {
@@ -37,7 +41,11 @@ const EventSearchPageContainer: React.FC<RouteComponentProps> = () => {
           return fetchMoreResult;
         },
         variables: {
-          ...getEventFilters(searchParams, PAGE_SIZE),
+          ...getEventFilters(
+            searchParams,
+            PAGE_SIZE,
+            EVENT_SORT_OPTIONS.END_TIME
+          ),
           page: page
         }
       });

--- a/src/domain/eventSearch/constants.ts
+++ b/src/domain/eventSearch/constants.ts
@@ -1,2 +1,13 @@
 // Page size of the event list
 export const PAGE_SIZE = 10;
+
+export enum EVENT_SORT_OPTIONS {
+  DURATION = "duration",
+  DURATION_DESC = "-duration",
+  END_TIME = "end_time",
+  END_TIME_DESC = "-end_time",
+  LAST_MODIFIED_TIME = "last_modified_time",
+  LAST_MODIFIED_TIME_DESC = "-last_modified_time",
+  START_TIME = "start_time",
+  START_TIME_DESC = "-start_time"
+}

--- a/src/domain/eventSearch/query.ts
+++ b/src/domain/eventSearch/query.ts
@@ -9,6 +9,7 @@ export const QUERY_EVENT_LIST = gql`
     $page: Int
     $pageSize: Int
     $publisher: ID
+    $sort: String
     $startDate: String
     $text: String
   ) {
@@ -20,6 +21,7 @@ export const QUERY_EVENT_LIST = gql`
       page: $page
       pageSize: $pageSize
       publisher: $publisher
+      sort: $sort
       startDate: $startDate
       text: $text
     ) {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -252,6 +252,7 @@ export type QueryEventListArgs = {
   page?: Maybe<Scalars['Int']>,
   pageSize?: Maybe<Scalars['Int']>,
   publisher?: Maybe<Scalars['ID']>,
+  sort?: Maybe<Scalars['String']>,
   startDate?: Maybe<Scalars['String']>,
   text?: Maybe<Scalars['String']>
 };
@@ -408,6 +409,7 @@ export type EventListQueryVariables = {
   page?: Maybe<Scalars['Int']>,
   pageSize?: Maybe<Scalars['Int']>,
   publisher?: Maybe<Scalars['ID']>,
+  sort?: Maybe<Scalars['String']>,
   startDate?: Maybe<Scalars['String']>,
   text?: Maybe<Scalars['String']>
 };
@@ -767,8 +769,8 @@ export type OrganizationDetailsQueryHookResult = ReturnType<typeof useOrganizati
 export type OrganizationDetailsLazyQueryHookResult = ReturnType<typeof useOrganizationDetailsLazyQuery>;
 export type OrganizationDetailsQueryResult = ApolloReactCommon.QueryResult<OrganizationDetailsQuery, OrganizationDetailsQueryVariables>;
 export const EventListDocument = gql`
-    query EventList($divisions: [String], $endDate: String, $keywords: [String], $locations: [String], $page: Int, $pageSize: Int, $publisher: ID, $startDate: String, $text: String) {
-  eventList(divisions: $divisions, endDate: $endDate, keywords: $keywords, locations: $locations, page: $page, pageSize: $pageSize, publisher: $publisher, startDate: $startDate, text: $text) {
+    query EventList($divisions: [String], $endDate: String, $keywords: [String], $locations: [String], $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $startDate: String, $text: String) {
+  eventList(divisions: $divisions, endDate: $endDate, keywords: $keywords, locations: $locations, page: $page, pageSize: $pageSize, publisher: $publisher, sort: $sort, startDate: $startDate, text: $text) {
     meta {
       count
       next
@@ -869,6 +871,7 @@ export function withEventList<TProps, TChildProps = {}>(operationOptions?: Apoll
  *      page: // value for 'page'
  *      pageSize: // value for 'pageSize'
  *      publisher: // value for 'publisher'
+ *      sort: // value for 'sort'
  *      startDate: // value for 'startDate'
  *      text: // value for 'text'
  *   },


### PR DESCRIPTION
Hide past events from the event search results. Also disable past dates from the datepicker. I also removed all option from date range filter menu
https://helsinkisolutionoffice.atlassian.net/browse/TH-214

Also display search results in chronological order
https://helsinkisolutionoffice.atlassian.net/browse/TH-218 