### PR TITLE
Use shortDescription for page metadata

### DIFF
--- a/src/domain/event/EventPageMeta.tsx
+++ b/src/domain/event/EventPageMeta.tsx
@@ -16,7 +16,7 @@ const EventPageMeta: React.FC<Props> = ({ eventData }) => {
     getLocalisedString(localizedObject, locale);
 
   const name = getLocal(eventData.eventDetails.name);
-  const description = getLocal(eventData.eventDetails.description || {});
+  const description = getLocal(eventData.eventDetails.shortDescription || {});
   const image = eventData.eventDetails.images.length
     ? eventData.eventDetails.images[0].url
     : null;

--- a/src/domain/event/__tests__/EventPageMeta.test.jsx
+++ b/src/domain/event/__tests__/EventPageMeta.test.jsx
@@ -32,10 +32,10 @@ test("applies expected metadata", async () => {
   const eventImage = "https://localhost/example/path";
   const mockEventData = {
     eventDetails: {
-      description: {
+      images: [{ url: eventImage }],
+      shortDescription: {
         fi: eventDescription
       },
-      images: [{ url: eventImage }],
       name: {
         fi: eventName
       }


### PR DESCRIPTION
ShortDescription is more suitable as it is shorter and does not contain
markup that should be parsed.