### PR TITLE
TH-221 | Fix angle icon not opening dropdown

### DIFF
--- a/src/common/components/dateSelector/dateSelector.module.scss
+++ b/src/common/components/dateSelector/dateSelector.module.scss
@@ -40,6 +40,7 @@
       height: 0.75rem;
       width: 0.75rem;
       margin-left: 0.75rem;
+      pointer-events: none;
     }
   }
 }

--- a/src/common/components/multiSelectDropdown/multiSelectDropdown.module.scss
+++ b/src/common/components/multiSelectDropdown/multiSelectDropdown.module.scss
@@ -51,6 +51,7 @@
       height: 0.75rem;
       width: 0.75rem;
       margin-left: 0.75rem;
+      pointer-events: none;
     }
   }
 }


### PR DESCRIPTION
We are listening for click events on the document to know when the user
clicks outside of the dropdown. We use this information to close the
dropdown.

We are repalcing the icon-angle-down with icon-angle-up when we
open the menu.

This results in a conflicting scenario. When this element ends up being
the click target, we will fail to find it from within the dropdown
element, because it gets replaced. This leads us to believe that the
element must then be outside of the dropdown, when in truth it does no
longer exist at all. Due to this, we end up closing the menu right after
we opened it, making it look like the menu does not open at all.

To stop this from happening, we are disabling pointer events for the
icons. That way the click will target their parent element, which is
not conditionally rendered.