### PR TITLE
TH-226 | Include additional keywords for category culture search

### DIFF
--- a/src/domain/eventSearch/EventListUtils.ts
+++ b/src/domain/eventSearch/EventListUtils.ts
@@ -9,7 +9,7 @@ import {
 import { EventListQuery } from "../../generated/graphql";
 import { formatDate } from "../../util/dateUtils";
 import getUrlParamAsString from "../../util/getUrlParamAsString";
-import { EVENT_SORT_OPTIONS } from "./constants";
+import { CULTURE_KEYWORDS, EVENT_SORT_OPTIONS } from "./constants";
 
 /**
  * Get start and end dates to event list filtering
@@ -108,7 +108,7 @@ export const getEventFilters = (
   const mappedCategories: string[] = categories.map(category => {
     switch (category) {
       case CATEGORIES.CULTURE:
-        return "yso:p360";
+        return Object.values(CULTURE_KEYWORDS).join(",");
       case CATEGORIES.DANCE:
         return "yso:p1278";
       case CATEGORIES.FOOD:

--- a/src/domain/eventSearch/constants.ts
+++ b/src/domain/eventSearch/constants.ts
@@ -11,3 +11,31 @@ export enum EVENT_SORT_OPTIONS {
   START_TIME = "start_time",
   START_TIME_DESC = "-start_time"
 }
+
+// Finnish keys are used for keywords that do not have an official English
+// translation. An approximate translation has been provided on the comment row.
+export const CULTURE_KEYWORDS = {
+  "Elokuva ja media": "kulke:205", // Films and Media
+  Sirkus: "kulke:51", // Circus
+  Teatteri: "kulke:33", // theatre
+  "Teatteri ja sirkus": "kulke:351", // Theatre and Circus
+  art: "yso:p2851",
+  "art exhibitions": "yso:p6889",
+  "art museums": "yso:p8144",
+  "cinema (art forms)": "yso:p16327",
+  "contemporary art": "yso:p9593",
+  "contemporary dance": "yso:p10105",
+  "cultural events": "yso:p360",
+  "dance (performing arts)": "yso:p1278",
+  exhibitions: "yso:p5121",
+  films: "yso:p1235",
+  "fine arts": "yso:p2739",
+  "literary art": "yso:p7969",
+  literature: "yso:p8113",
+  "modern art": "yso:p9592",
+  museums: "yso:p4934",
+  music: "yso:p1808",
+  "performing arts": "yso:p2850",
+  teatteri: "matko:teatteri", // theatre
+  theatre: "yso:p2625" // in Finnish teatteritaide, "theatre arts"
+};


### PR DESCRIPTION
These were defined by the project manager. Further documentation can be
found from TH-226.

-----

I created a new keyword dictionary. I used the official terminology I could find which is why some keys are in Finnish and some are English. If you know a better method, I am listening :D I translated the Finnish keywords in the comments in order to avoid the situation where someone is lead to think that dev translations are official.

I wanted to use a dictionary in order to provide a human legible label for developers. This should make it easier when new ones are added or old ones are removed.

I added all the keywords in the Jira issue. There were lots of other tags which looked like they could be relevant as well, but I avoided them for now.

The only exception is `Teatteri`. The list contained `teatteri`, but its id was prefixed with `matko`. The rest of the tags were prefixed with a `kulke` or `yso`. `Teatteri`'s id was prefixed with `kulke`. So I included both `teatteri` and `Teatteri`.