### PR TITLE
TH-795 | Landing page hero improvements

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,11 @@
+export const BREAKPOINTS = {
+  XS: 576,
+  SM: 768,
+  MD: 1024,
+  LG: 1200,
+  XLG: 1600,
+};
+
 export const AUTOSUGGEST_KEYWORD_BLACK_LIST = [
   'kulke:354', // Seniorit
 ];

--- a/src/domain/landingPage/landingPageHero/LandingPageHero.tsx
+++ b/src/domain/landingPage/landingPageHero/LandingPageHero.tsx
@@ -7,8 +7,34 @@ import Container from '../../../domain/app/layout/Container';
 import { LandingPageFieldsFragment } from '../../../generated/graphql';
 import useBreakpoint from '../../../hooks/useBreakpoint';
 import useLocale from '../../../hooks/useLocale';
+import { Breakpoint } from '../../../types';
 import { getLandingPageFields } from '../utils';
 import styles from './landingPageHero.module.scss';
+
+const getTextWrapperMaxWidth = (breakpoint: Breakpoint) => {
+  switch (breakpoint) {
+    case 'xs':
+    case 'sm':
+      return undefined;
+    case 'md':
+      return 400;
+    case 'lg':
+    case 'xlg':
+      return 560;
+  }
+};
+
+const getTextFontSize = (breakpoint: Breakpoint) => {
+  switch (breakpoint) {
+    case 'xs':
+    case 'sm':
+    case 'md':
+      return 52;
+    case 'lg':
+    case 'xlg':
+      return 80;
+  }
+};
 
 interface Props {
   landingPage: LandingPageFieldsFragment;
@@ -39,35 +65,10 @@ const LandingPageHero: React.FC<Props> = ({ landingPage }) => {
   // will take space of max-width and there might be wider right padding.
   // So we need to calculate the max-width of each text row and set max-width of
   // text wrapper to same
-  const calculatedTextWrapperWidth = React.useMemo(() => {
-    const getTextWrapperMaxWidth = () => {
-      switch (breakpoint) {
-        case 'xs':
-        case 'sm':
-          return undefined;
-        case 'md':
-          return 400;
-        case 'lg':
-        case 'xlg':
-          return 560;
-      }
-    };
+  const calculateTextWrapperWidth = () => {
+    const maxTextWrapperWidth = getTextWrapperMaxWidth(breakpoint);
 
-    const getTextFontSize = () => {
-      switch (breakpoint) {
-        case 'xs':
-        case 'sm':
-        case 'md':
-          return 52;
-        case 'lg':
-        case 'xlg':
-          return 80;
-      }
-    };
-
-    const maxTextWrapperWidth = getTextWrapperMaxWidth();
-
-    const font = `600 ${getTextFontSize()}px HelsinkiGrotesk`;
+    const font = `600 ${getTextFontSize(breakpoint)}px HelsinkiGrotesk`;
     const canvas = document.createElement('canvas');
     const context = canvas.getContext('2d');
 
@@ -107,7 +108,9 @@ const LandingPageHero: React.FC<Props> = ({ landingPage }) => {
     }
 
     return null;
-  }, [breakpoint, title]);
+  };
+
+  const calculatedTextWrapperWidth = calculateTextWrapperWidth();
 
   return (
     <div

--- a/src/domain/landingPage/landingPageHero/LandingPageHero.tsx
+++ b/src/domain/landingPage/landingPageHero/LandingPageHero.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import Container from '../../../domain/app/layout/Container';
 import { LandingPageFieldsFragment } from '../../../generated/graphql';
+import useBreakpoint from '../../../hooks/useBreakpoint';
 import useLocale from '../../../hooks/useLocale';
 import { getLandingPageFields } from '../utils';
 import styles from './landingPageHero.module.scss';
@@ -15,6 +16,7 @@ interface Props {
 
 const LandingPageHero: React.FC<Props> = ({ landingPage }) => {
   const locale = useLocale();
+  const breakpoint = useBreakpoint();
 
   const {
     backgroundColor,
@@ -31,6 +33,77 @@ const LandingPageHero: React.FC<Props> = ({ landingPage }) => {
   const moveToCollectionPage = () => {
     window.open(buttonUrl || '', '_self');
   };
+
+  const width = React.useMemo(() => {
+    const getTextMaxWidth = (): number | undefined => {
+      switch (breakpoint) {
+        case 'xs':
+        case 'sm':
+          return undefined;
+        case 'md':
+          return 400;
+        case 'lg':
+        case 'xlg':
+          return 560;
+      }
+    };
+
+    const getTextFontSize = (): number => {
+      switch (breakpoint) {
+        case 'xs':
+        case 'sm':
+        case 'md':
+          return 52;
+        case 'lg':
+        case 'xlg':
+          return 80;
+      }
+    };
+
+    const maxTextWidth = getTextMaxWidth();
+
+    if (!maxTextWidth || !title) {
+      return undefined;
+    }
+
+    const font = `600 ${getTextFontSize()}px HelsinkiGrotesk`;
+    const canvas: HTMLCanvasElement = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    if (context) {
+      context.font = font;
+
+      const textParts = title.trim().split(' ');
+      let i = 0;
+      let text = textParts[i];
+      let maxWidth = 0;
+      let prevWidth = 0;
+      let width = 0;
+
+      while (i < textParts.length) {
+        width = context.measureText(text).width;
+
+        if (width <= maxTextWidth) {
+          prevWidth = width;
+          i = i + 1;
+          text = [text, textParts[i]].join(' ');
+        } else {
+          if (text === textParts[i]) {
+            maxWidth = Math.max(maxWidth, width);
+            i = i + 1;
+          } else {
+            maxWidth = Math.max(maxWidth, prevWidth);
+          }
+          text = textParts[i];
+        }
+      }
+
+      const formattedWidth = Math.ceil(Math.max(maxWidth, width));
+      return formattedWidth;
+    } else {
+      return undefined;
+    }
+  }, [breakpoint, title]);
 
   return (
     <div
@@ -60,6 +133,7 @@ const LandingPageHero: React.FC<Props> = ({ landingPage }) => {
             styles.content,
             styles[`color${capitalize(titleAndDescriptionColor)}`]
           )}
+          style={{ maxWidth: width ? width + 1 : undefined }}
         >
           <div className={styles.description}>{description}</div>
           <h1 className={styles.title}>{title}</h1>

--- a/src/domain/landingPage/landingPageHero/LandingPageHero.tsx
+++ b/src/domain/landingPage/landingPageHero/LandingPageHero.tsx
@@ -67,16 +67,11 @@ const LandingPageHero: React.FC<Props> = ({ landingPage }) => {
 
     const maxTextWrapperWidth = getTextWrapperMaxWidth();
 
-    // Return null if screen size is small or title is not defined
-    if (!maxTextWrapperWidth || !title) {
-      return null;
-    }
-
     const font = `600 ${getTextFontSize()}px HelsinkiGrotesk`;
     const canvas = document.createElement('canvas');
     const context = canvas.getContext('2d');
 
-    if (context) {
+    if (context && maxTextWrapperWidth && title) {
       context.font = font;
 
       const words = title.trim().split(' ');

--- a/src/domain/landingPage/landingPageHero/__tests__/__snapshots__/LandingPageHero.test.tsx.snap
+++ b/src/domain/landingPage/landingPageHero/__tests__/__snapshots__/LandingPageHero.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`matches snapshot 1`] = `
   >
     <div
       class="content colorWhite"
-      style="max-width: 262px;"
     >
       <div
         class="description"

--- a/src/domain/landingPage/landingPageHero/__tests__/__snapshots__/LandingPageHero.test.tsx.snap
+++ b/src/domain/landingPage/landingPageHero/__tests__/__snapshots__/LandingPageHero.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`matches snapshot 1`] = `
   >
     <div
       class="content colorWhite"
+      style="max-width: 262px;"
     >
       <div
         class="description"

--- a/src/domain/landingPage/landingPageHero/landingPageHero.module.scss
+++ b/src/domain/landingPage/landingPageHero/landingPageHero.module.scss
@@ -8,8 +8,11 @@
   padding-bottom: 6rem;
 
   @include respond-above(sm) {
-    min-height: 42.6875rem;
     padding-bottom: unset;
+  }
+
+  @include respond-above(md) {
+    min-height: 42.6875rem;
   }
 
   .desktopBackgroundImage {

--- a/src/hooks/__tests__/useBreakpoint.test.tsx
+++ b/src/hooks/__tests__/useBreakpoint.test.tsx
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import useBreakpoint from '../useBreakpoint';
+
+test('should return correct breakpoint', async () => {
+  global.innerWidth = 500;
+  const { result } = renderHook(() => useBreakpoint());
+
+  expect(result.current).toBe('xs');
+
+  act(() => {
+    global.innerWidth = 700;
+    global.dispatchEvent(new Event('resize'));
+  });
+  expect(result.current).toBe('sm');
+
+  act(() => {
+    global.innerWidth = 1000;
+    global.dispatchEvent(new Event('resize'));
+  });
+  expect(result.current).toBe('md');
+
+  act(() => {
+    global.innerWidth = 1100;
+    global.dispatchEvent(new Event('resize'));
+  });
+  expect(result.current).toBe('lg');
+
+  act(() => {
+    global.innerWidth = 1500;
+    global.dispatchEvent(new Event('resize'));
+  });
+  expect(result.current).toBe('xlg');
+});

--- a/src/hooks/__tests__/useTextWrapperWidth.test.tsx
+++ b/src/hooks/__tests__/useTextWrapperWidth.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useTextWrapperWidth from '../useTextWrapperWidth';
+
+test('should return correct text wrapper width', async () => {
+  const { result } = renderHook(() =>
+    useTextWrapperWidth({
+      font: `600 52px Arial`,
+      maxTextWrapperWidth: 400,
+      title: 'Wow! Kaiken maailman kulttuuria',
+    })
+  );
+
+  expect(result.current).toBe(322);
+
+  const { result: result2 } = renderHook(() =>
+    useTextWrapperWidth({
+      font: `600 80px Arial`,
+      maxTextWrapperWidth: 560,
+      title: 'Wow! Kaiken maailman kulttuuria',
+    })
+  );
+
+  expect(result2.current).toBe(495);
+});
+
+test('should return greater value than maxTextWrapperWidth when single word is overflowing', async () => {
+  const { result } = renderHook(() =>
+    useTextWrapperWidth({
+      font: `600 80px Arial`,
+      maxTextWrapperWidth: 560,
+      title: 'Veryverylongword',
+    })
+  );
+
+  expect(result.current).toBe(691);
+});
+
+test('should return null', async () => {
+  const { result } = renderHook(() =>
+    useTextWrapperWidth({
+      font: `600 52px Arial`,
+      maxTextWrapperWidth: 400,
+      title: '',
+    })
+  );
+
+  expect(result.current).toBeNull();
+
+  const { result: result2 } = renderHook(() =>
+    useTextWrapperWidth({
+      font: `600 80px Arial`,
+      maxTextWrapperWidth: null,
+      title: 'Wow! Kaiken maailman kulttuuria',
+    })
+  );
+
+  expect(result2.current).toBeNull();
+});

--- a/src/hooks/useBreakpoint.tsx
+++ b/src/hooks/useBreakpoint.tsx
@@ -1,0 +1,23 @@
+import { BREAKPOINTS } from '../constants';
+import { Breakpoint } from '../types';
+import useWindowSize from './useWindowSize';
+
+const useBreakpoint = (): Breakpoint => {
+  const windowSize = useWindowSize();
+  /* istanbul ignore next */
+  if (windowSize.width === undefined) {
+    return 'lg';
+  } else if (windowSize.width <= BREAKPOINTS.XS) {
+    return 'xs';
+  } else if (windowSize.width <= BREAKPOINTS.SM) {
+    return 'sm';
+  } else if (windowSize.width <= BREAKPOINTS.MD) {
+    return 'md';
+  } else if (windowSize.width <= BREAKPOINTS.LG) {
+    return 'lg';
+  } else {
+    return 'xlg';
+  }
+};
+
+export default useBreakpoint;

--- a/src/hooks/useBreakpoint.tsx
+++ b/src/hooks/useBreakpoint.tsx
@@ -7,13 +7,13 @@ const useBreakpoint = (): Breakpoint => {
   /* istanbul ignore next */
   if (windowSize.width === undefined) {
     return 'lg';
-  } else if (windowSize.width <= BREAKPOINTS.XS) {
+  } else if (windowSize.width < BREAKPOINTS.XS) {
     return 'xs';
-  } else if (windowSize.width <= BREAKPOINTS.SM) {
+  } else if (windowSize.width < BREAKPOINTS.SM) {
     return 'sm';
-  } else if (windowSize.width <= BREAKPOINTS.MD) {
+  } else if (windowSize.width < BREAKPOINTS.MD) {
     return 'md';
-  } else if (windowSize.width <= BREAKPOINTS.LG) {
+  } else if (windowSize.width < BREAKPOINTS.LG) {
     return 'lg';
   } else {
     return 'xlg';

--- a/src/hooks/useTextWrapperWidth.tsx
+++ b/src/hooks/useTextWrapperWidth.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+// We want to have event padding for the text wrapper. By using pure CSS we can set
+// max-width for the wrapper but when the text is longer that max-width the text
+// will take space of max-width and there might be wider right padding.
+// So we need to calculate the max-width of each text row and set max-width of
+// text wrapper to same
+const useTextWrapperWidth = ({
+  font,
+  maxTextWrapperWidth,
+  title,
+}: {
+  font: string;
+  maxTextWrapperWidth: number | undefined;
+  title: string;
+}): number | null => {
+  const textWrapperWidth = React.useMemo(() => {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    if (context && maxTextWrapperWidth && title) {
+      context.font = font;
+
+      const words = title.trim().split(' ');
+      let i = 0;
+      let text = words[i];
+      let maxTextWidth = 0;
+      let prevTextWidth = 0;
+      let textWidth = 0;
+
+      // Loop through all the words
+      while (i < words.length) {
+        textWidth = context.measureText(text).width;
+
+        if (textWidth <= maxTextWrapperWidth) {
+          // Add new word to text if text width is smaller than max text wrapper width
+          prevTextWidth = textWidth;
+          i = i + 1;
+          text = [text, words[i]].join(' ');
+        } else {
+          if (text === words[i]) {
+            // If single word is longer than max text wrapper width compare
+            // maxTextWidth and single word width
+            maxTextWidth = Math.max(maxTextWidth, textWidth);
+            i = i + 1;
+          } else {
+            maxTextWidth = Math.max(maxTextWidth, prevTextWidth);
+          }
+          text = words[i];
+        }
+      }
+
+      return Math.ceil(maxTextWidth);
+    }
+
+    return null;
+  }, [font, maxTextWrapperWidth, title]);
+
+  return textWrapperWidth;
+};
+
+export default useTextWrapperWidth;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
 export type Language = 'en' | 'fi' | 'sv';
 
+export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xlg';
+
 export type LandingPageTextColor = 'BLACK' | 'WHITE';


### PR DESCRIPTION
## Description
Calculate max-width of landing page text container to have event padding

## Closes
**[TH-795](https://helsinkisolutionoffice.atlassian.net/browse/TH-795)**

## Screenshots
<img width="1244" alt="Näyttökuva 2020-9-25 kello 14 53 41" src="https://user-images.githubusercontent.com/24706814/94264214-f3b4f780-ff3e-11ea-970b-fe9a86180721.png">
