### PR TITLE
TH-879 | Add polyfills for Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
       "not op_mini all"
     ],
     "development": [
+      "ie11",
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
       "not op_mini all"
     ],
     "development": [
-      "ie11",
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
       href="%PUBLIC_URL%/images/apple-touch-icon.png"
     />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <!-- This polyfill is to fix https://helsinkisolutionoffice.atlassian.net/browse/TH-879 -->
+    <!-- Microsoft Edge 44.18362.449.0 needs this polyfill is to get rid of 'TextEncoder is not defined' error -->
     <script src="https://cdn.jsdelivr.net/npm/text-encoding@0.7.0/lib/encoding.min.js"></script>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,8 @@
       href="%PUBLIC_URL%/images/apple-touch-icon.png"
     />
     <meta name="msapplication-TileColor" content="#da532c" />
+    <!-- This polyfill is to fix https://helsinkisolutionoffice.atlassian.net/browse/TH-879 -->
+    <script src="https://cdn.jsdelivr.net/npm/text-encoding@0.7.0/lib/encoding.min.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/domain/landingPage/landingPageHero/landingPageHero.module.scss
+++ b/src/domain/landingPage/landingPageHero/landingPageHero.module.scss
@@ -68,6 +68,7 @@
     width: 100%;
     box-sizing: border-box;
     transition: background-color 0.2s ease;
+    position: relative;
 
     @include respond-above(sm) {
       margin-bottom: 10rem;

--- a/src/domain/landingPage/landingPageSearch/landingPageSearch.module.scss
+++ b/src/domain/landingPage/landingPageSearch/landingPageSearch.module.scss
@@ -6,6 +6,7 @@
   background-color: #464646;
   padding: var(--spacing-l) var(--spacing-m);
   z-index: 1;
+  position: relative;
 
   @include respond-above(sm) {
     padding: var(--spacing-xl);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 
 import * as Sentry from '@sentry/browser';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,6 @@
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+
 import * as Sentry from '@sentry/browser';
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
## Description
Fix `TextEncoder not defined` for Microsoft Edge 44.18362.449.0
Fix small layout problems for Microsoft Edge 44.18362.449.0

## Closes
[TH-879](https://helsinkisolutionoffice.atlassian.net/browse/TH-879)

## Testing
Can be tested e.g. using Browser stack: https://live.browserstack.com/dashboard#os=Windows&os_version=10&browser=Edge&browser_version=18.0&zoom_to_fit=true&full_screen=true&resolution=responsive-mode&url=https%3A%2F%2Fevents-helsinki-ui-qa-r-fix-edge-pol-zv2jqv.test.kuva.hel.ninja&speed=1