### PR TITLE
Fix division in event search

### DIFF
--- a/src/domain/app/routes/__tests__/AppRoutes.test.tsx
+++ b/src/domain/app/routes/__tests__/AppRoutes.test.tsx
@@ -22,7 +22,6 @@ import {
   screen,
   waitFor,
 } from '../../../../util/testUtils';
-import { MAPPED_PLACES } from '../../../eventSearch/constants';
 import AppRoutes from '../AppRoutes';
 
 const placeToPlaceString = {
@@ -54,7 +53,6 @@ const collectionListResponse = {
 const eventListResponse = { data: { eventList: fakeEvents(3) } };
 
 const eventListBaseVariables = {
-  allOngoingAnd: [],
   end: '',
   include: ['keywords', 'location'],
   isFree: undefined,

--- a/src/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
+++ b/src/domain/event/similarEvents/__tests__/SimilarEvents.test.tsx
@@ -18,7 +18,6 @@ import SimilarEvents from '../SimilarEvents';
 const keywordIds = ['yso:1', 'yso:2'];
 
 const variables = {
-  allOngoingAnd: [],
   end: '',
   include: ['keywords', 'location'],
   isFree: undefined,

--- a/src/domain/eventSearch/query.ts
+++ b/src/domain/eventSearch/query.ts
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 export const QUERY_EVENT_LIST = gql`
   query EventList(
     $allOngoingAnd: [String]
+    $division: [String]
     $end: String
     $endsAfter: String
     $endsBefore: String
@@ -13,6 +14,7 @@ export const QUERY_EVENT_LIST = gql`
     $keywordAnd: [String]
     $keywordNot: [String]
     $language: String
+    $localOngoingAnd: [String]
     $location: [String]
     $page: Int
     $pageSize: Int
@@ -28,6 +30,7 @@ export const QUERY_EVENT_LIST = gql`
   ) {
     eventList(
       allOngoingAnd: $allOngoingAnd
+      division: $division
       end: $end
       endsAfter: $endsAfter
       endsBefore: $endsBefore
@@ -38,6 +41,7 @@ export const QUERY_EVENT_LIST = gql`
       keywordAnd: $keywordAnd
       keywordNot: $keywordNot
       language: $language
+      localOngoingAnd: $localOngoingAnd
       location: $location
       page: $page
       pageSize: $pageSize

--- a/src/domain/eventSearch/utils.tsx
+++ b/src/domain/eventSearch/utils.tsx
@@ -16,7 +16,7 @@ import isNumber from 'lodash/isNumber';
 import React from 'react';
 
 import { DATE_TYPES } from '../../constants';
-import { Meta } from '../../generated/graphql';
+import { Meta, QueryEventListArgs } from '../../generated/graphql';
 import IconCultureAndArts from '../../icons/IconCultureAndArts';
 import IconDance from '../../icons/IconDance';
 import IconFood from '../../icons/IconFood';
@@ -175,7 +175,7 @@ export const getEventSearchVariables = ({
   sortOrder: EVENT_SORT_OPTIONS;
   superEventType: string[];
   place?: string;
-}) => {
+}): QueryEventListArgs => {
   const {
     categories,
     dateTypes,
@@ -221,11 +221,13 @@ export const getEventSearchVariables = ({
     .map((category) => MAPPED_CATEGORIES[category])
     .filter((e) => e);
 
+  const hasDivisions = !isEmpty(divisions);
+  const hasText = !isEmpty(text);
   // Combine and add keywords
-
   return {
-    allOngoingAnd: text,
-    ...(!isEmpty(divisions) && { division: divisions.sort() }),
+    ...(hasText &&
+      (hasDivisions ? { localOngoingAnd: text } : { allOngoingAnd: text })),
+    ...(hasDivisions && { division: divisions.sort() }),
     end,
     include,
     isFree: isFree || undefined,

--- a/src/domain/eventSearch/utils.tsx
+++ b/src/domain/eventSearch/utils.tsx
@@ -221,13 +221,13 @@ export const getEventSearchVariables = ({
     .map((category) => MAPPED_CATEGORIES[category])
     .filter((e) => e);
 
-  const hasDivisions = !isEmpty(divisions);
+  const hasLocation = !isEmpty(divisions) || !isEmpty(places);
   const hasText = !isEmpty(text);
   // Combine and add keywords
   return {
     ...(hasText &&
-      (hasDivisions ? { localOngoingAnd: text } : { allOngoingAnd: text })),
-    ...(hasDivisions && { division: divisions.sort() }),
+      (hasLocation ? { localOngoingAnd: text } : { allOngoingAnd: text })),
+    ...(hasLocation && { division: divisions.sort() }),
     end,
     include,
     isFree: isFree || undefined,

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -795,6 +795,7 @@ export type EventDetailsQuery = (
 
 export type EventListQueryVariables = {
   allOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
+  division?: Maybe<Array<Maybe<Scalars['String']>>>,
   end?: Maybe<Scalars['String']>,
   endsAfter?: Maybe<Scalars['String']>,
   endsBefore?: Maybe<Scalars['String']>,
@@ -805,6 +806,7 @@ export type EventListQueryVariables = {
   keywordAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
   keywordNot?: Maybe<Array<Maybe<Scalars['String']>>>,
   language?: Maybe<Scalars['String']>,
+  localOngoingAnd?: Maybe<Array<Maybe<Scalars['String']>>>,
   location?: Maybe<Array<Maybe<Scalars['String']>>>,
   page?: Maybe<Scalars['Int']>,
   pageSize?: Maybe<Scalars['Int']>,
@@ -1592,8 +1594,8 @@ export type EventDetailsQueryHookResult = ReturnType<typeof useEventDetailsQuery
 export type EventDetailsLazyQueryHookResult = ReturnType<typeof useEventDetailsLazyQuery>;
 export type EventDetailsQueryResult = ApolloReactCommon.QueryResult<EventDetailsQuery, EventDetailsQueryVariables>;
 export const EventListDocument = gql`
-    query EventList($allOngoingAnd: [String], $end: String, $endsAfter: String, $endsBefore: String, $inLanguage: String, $include: [String], $isFree: Boolean, $keyword: [String], $keywordAnd: [String], $keywordNot: [String], $language: String, $location: [String], $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $startsAfter: String, $startsBefore: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String) {
-  eventList(allOngoingAnd: $allOngoingAnd, end: $end, endsAfter: $endsAfter, endsBefore: $endsBefore, include: $include, inLanguage: $inLanguage, isFree: $isFree, keyword: $keyword, keywordAnd: $keywordAnd, keywordNot: $keywordNot, language: $language, location: $location, page: $page, pageSize: $pageSize, publisher: $publisher, sort: $sort, start: $start, startsAfter: $startsAfter, startsBefore: $startsBefore, superEvent: $superEvent, superEventType: $superEventType, text: $text, translation: $translation) {
+    query EventList($allOngoingAnd: [String], $division: [String], $end: String, $endsAfter: String, $endsBefore: String, $inLanguage: String, $include: [String], $isFree: Boolean, $keyword: [String], $keywordAnd: [String], $keywordNot: [String], $language: String, $localOngoingAnd: [String], $location: [String], $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $startsAfter: String, $startsBefore: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String) {
+  eventList(allOngoingAnd: $allOngoingAnd, division: $division, end: $end, endsAfter: $endsAfter, endsBefore: $endsBefore, include: $include, inLanguage: $inLanguage, isFree: $isFree, keyword: $keyword, keywordAnd: $keywordAnd, keywordNot: $keywordNot, language: $language, localOngoingAnd: $localOngoingAnd, location: $location, page: $page, pageSize: $pageSize, publisher: $publisher, sort: $sort, start: $start, startsAfter: $startsAfter, startsBefore: $startsBefore, superEvent: $superEvent, superEventType: $superEventType, text: $text, translation: $translation) {
     meta {
       count
       next
@@ -1630,6 +1632,7 @@ export function withEventList<TProps, TChildProps = {}>(operationOptions?: Apoll
  * const { data, loading, error } = useEventListQuery({
  *   variables: {
  *      allOngoingAnd: // value for 'allOngoingAnd'
+ *      division: // value for 'division'
  *      end: // value for 'end'
  *      endsAfter: // value for 'endsAfter'
  *      endsBefore: // value for 'endsBefore'
@@ -1640,6 +1643,7 @@ export function withEventList<TProps, TChildProps = {}>(operationOptions?: Apoll
  *      keywordAnd: // value for 'keywordAnd'
  *      keywordNot: // value for 'keywordNot'
  *      language: // value for 'language'
+ *      localOngoingAnd: // value for 'localOngoingAnd'
  *      location: // value for 'location'
  *      page: // value for 'page'
  *      pageSize: // value for 'pageSize'


### PR DESCRIPTION
## Description :sparkles:

Fix problem that division is ignored from event search. Also use always localOngoingSearch when division is selected in order to remove onlineEvents from division searches.
Tried to write regression test but it went too complicated because of complex apollo mocks that wont fit on this scenario.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: