### PR TITLE
TH-918: Added unit tests for onGoing-event list parameters

### DIFF
--- a/src/domain/eventSearch/__tests__/utils.test.ts
+++ b/src/domain/eventSearch/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
   CATEGORIES,
   DEFAULT_SEARCH_FILTERS,
   EVENT_SORT_OPTIONS,
+  MAPPED_PLACES,
 } from '../constants';
 import { getEventSearchVariables, getNextPage, getSearchQuery } from '../utils';
 
@@ -219,6 +220,65 @@ describe('getEventSearchVariables function', () => {
       params: new URLSearchParams(`?divisions=kunta:espoo`),
     });
     expect(division).toContain('kunta:espoo');
+  });
+
+  it('should not use *Ongoing params when no text present', () => {
+    const {
+      allOngoingAnd,
+      localOngoingAnd,
+      division,
+    } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(),
+    });
+    expect(division).toBeUndefined();
+    expect(allOngoingAnd).toBeUndefined();
+    expect(localOngoingAnd).toBeUndefined();
+  });
+
+  it('should use allOngoing without division when only text present', () => {
+    const {
+      allOngoingAnd,
+      localOngoingAnd,
+      division,
+    } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?text=Rock`),
+    });
+    expect(division).toBeUndefined();
+    expect(allOngoingAnd).toEqual(['Rock']);
+    expect(localOngoingAnd).toBeUndefined();
+  });
+
+  it('should search localOngoing when division given', () => {
+    const {
+      allOngoingAnd,
+      localOngoingAnd,
+      division,
+    } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(
+        `?text=Rock&divisions=kaupunginosa:alppiharju`
+      ),
+    });
+    expect(division).toContain('kaupunginosa:alppiharju');
+    expect(allOngoingAnd).toBeUndefined();
+    expect(localOngoingAnd).toEqual(['Rock']);
+  });
+
+  it('should search localOngoing when a place given', () => {
+    const place = MAPPED_PLACES['annantalo'];
+    const {
+      allOngoingAnd,
+      localOngoingAnd,
+      location,
+    } = getEventSearchVariables({
+      ...defaultParams,
+      params: new URLSearchParams(`?text=Rock&places=${place}`),
+    });
+    expect(location).toContain(place);
+    expect(allOngoingAnd).toBeUndefined();
+    expect(localOngoingAnd).toEqual(['Rock']);
   });
 });
 


### PR DESCRIPTION
## Description :sparkles:
TH-918: Added unit tests for onGoing-event list parameters. Also added some division parameter tests

## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/TH-918

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: