### PR TITLE
TH-938 | Update Dockerfile to generate smaller image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !public
 !src
 !package.json
+!package.prod.json
 !tsconfig.json
 !yarn.lock
 !.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN yarn policies set-version $YARN_VERSION
 USER appuser
 
 # Install dependencies
-COPY --chown=appuser:appuser package*.json *yarn* /app/
+COPY --chown=appuser:appuser package.json *yarn* /app/
 RUN yarn && yarn cache clean --force
 
 # Copy all files

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,10 @@ ENV NODE_ENV $NODE_ENV
 # Bake package.json start command into the image
 CMD ["yarn", "start"]
 
-# ==========================================
-FROM appbase as production
-# ==========================================
+# =============================
+FROM appbase as prodbuilder
+# =============================
+
 # Use non-root user
 USER appuser
 
@@ -81,8 +82,20 @@ ARG REACT_APP_GTM_PREVIEW
 # Build application
 RUN yarn build
 
+# ==========================================
+FROM helsinkitest/node:12-slim as production
+# ==========================================
+# Use non-root user
+USER appuser
+
+COPY --chown=appuser:appuser package.prod.json /app/package.json
+RUN yarn && yarn cache clean --force
+
+COPY --chown=appuser:appuser --from=prodbuilder /app/build/ /app/build/
+
 # Expose port
 EXPOSE 3001
 
 # Start ssr server
 CMD yarn start:server
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Start the container
 
 The web application should run at http://localhost:3001
 
+Production docker container uses `package.prod.json` file instead of `package.json` to only included needed packages for server side code in the final image (to reduce image size). Whole node_modules directory from previous stages is not needed.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: events-helsinki-client
     build:
       context: .
-      target: ${DOCKER_TARGET:-development}
+      target: ${DOCKER_TARGET:-production}
     volumes:
       - '.:/app'
       - '/app/node_modules'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: events-helsinki-client
     build:
       context: .
-      target: ${DOCKER_TARGET:-production}
+      target: ${DOCKER_TARGET:-development}
     volumes:
       - '.:/app'
       - '/app/node_modules'

--- a/package.prod.json
+++ b/package.prod.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "canvas": "^2.6.1"
+  },
+  "scripts": {
+    "start:server": "node build/server.js"
+  }
+}

--- a/package.prod.json
+++ b/package.prod.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "canvas": "^2.6.1"
+    "canvas": "2.6.1"
   },
   "scripts": {
     "start:server": "node build/server.js"


### PR DESCRIPTION
## Description :sparkles:

- Update Dockerfile to generate smaller image

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

Production build seems to have one external dependency (canvas). We can reduce the final image size by just installing that package in the image. Seems to work.

There seemed to be some errors if you try to remove the external dependecy from webpack config.