### PR TITLE
Fix: Lint stage skips ignored files

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged -c .lintstagedrc.js"
   }
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,7 +1,0 @@
-{
-  "*.{js,jsx,tsx}": [
-    "yarn format-code",
-    "yarn test:staged",
-    "prettier --write",
-  ]
-}

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -2,6 +2,14 @@ const { CLIEngine } = require('eslint');
 
 const cli = new CLIEngine({});
 
+/**
+ * ESLint throws out warning:
+ * "File ignored because of a matching ignore pattern. Use "--no-ignore" to override"
+ * that breaks the linting process when --max-warnings=0 is set.
+ * Based on the discussion from this issue: https://github.com/eslint/eslint/issues/9977,
+ * it seems that using the outlined script is the best route to fix this: https://github.com/eslint/eslint/issues/9977#issuecomment-406420893
+ * See also: https://openbase.io/js/lint-staged/documentation
+ */
 module.exports = {
   '**/*.{ts,tsx,js,jsx}': [
     (changedFiles) =>

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,13 @@
+const { CLIEngine } = require('eslint');
+
+const cli = new CLIEngine({});
+
+module.exports = {
+  '**/*.{ts,tsx,js,jsx}': [
+    (changedFiles) =>
+      'yarn format-code ' +
+      changedFiles.filter((file) => !cli.isPathIgnored(file)).join(' '),
+    'yarn test:staged',
+    'prettier --write',
+  ],
+};


### PR DESCRIPTION
## Description :sparkles:

If you have regenerated `graphql.tsx` which is ignored, you get the following failure on pre-commit becayse the file is picked up by changed files:
 `0:0 warning File ignored because of a matching ignore pattern. Use “--no-ignore” to override`
 
This will fix the problem.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: