### PR TITLE
Deploy to staging from master branch

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,7 +2,7 @@ name: Build & Staging
 on:
   push:
     branches:
-      - develop
+      - master
 
 env:
   CONTAINER_REGISTRY: ghcr.io


### PR DESCRIPTION
## Description :sparkles:
As the title says, let's start to deploy to staging from master instead of develop. Develop is still left for the gitlab.

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: