### PR TITLE
Fix broken code after codegen

### DIFF
--- a/src/domain/landingPage/utils.ts
+++ b/src/domain/landingPage/utils.ts
@@ -12,7 +12,7 @@ export const isLanguageSupported = (
   landingPage: LandingPageFieldsFragment,
   locale: Language
 ): boolean => {
-  return Boolean(landingPage.title?.[locale]);
+  return Boolean(landingPage.pageTitle?.[locale]);
 };
 
 /**

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -247,7 +247,16 @@ export type LandingPage = {
   lastPublishedAt?: Maybe<Scalars['String']>;
   latestRevisionCreatedAt?: Maybe<Scalars['String']>;
   title?: Maybe<LocalizedObject>;
+  description?: Maybe<LocalizedObject>;
   keywords?: Maybe<LocalizedCmsKeywords>;
+  titleAndDescriptionColor?: Maybe<LocalizedObject>;
+  buttonText?: Maybe<LocalizedObject>;
+  buttonUrl?: Maybe<LocalizedObject>;
+  heroBackgroundImage?: Maybe<LocalizedCmsImage>;
+  heroBackgroundImageMobile?: Maybe<LocalizedCmsImage>;
+  heroBackgroundImageColor?: Maybe<LocalizedObject>;
+  heroTopLayerImage?: Maybe<LocalizedCmsImage>;
+  socialMediaImage?: Maybe<LocalizedCmsImage>;
   metaInformation?: Maybe<LocalizedObject>;
   pageTitle?: Maybe<LocalizedObject>;
   contentType?: Maybe<Scalars['Int']>;
@@ -858,7 +867,6 @@ export type LandingPageFieldsFragment = { __typename?: 'LandingPage' } & Pick<
     keywords: Maybe<
       { __typename?: 'LocalizedCmsKeywords' } & LocalizedCmsKeywordsFragment
     >;
-    title: Maybe<{ __typename?: 'LocalizedObject' } & LocalizedFieldsFragment>;
     topBanner: Maybe<{ __typename?: 'BannerPage' } & BannerPageFieldsFragment>;
     bottomBanner: Maybe<
       { __typename?: 'BannerPage' } & BannerPageFieldsFragment
@@ -1296,9 +1304,6 @@ export const LandingPageFieldsFragmentDoc = gql`
     }
     keywords {
       ...localizedCmsKeywords
-    }
-    title {
-      ...localizedFields
     }
     topBanner {
       ...BannerPageFields


### PR DESCRIPTION
## Description :sparkles:
Fix this one on master (coming after codegen for latest api-proxy):
```
TypeScript error in /Users/codelicious/workspace/events-helsinki-ui/src/domain/landingPage/utils.ts(15,30):
Property 'title' does not exist on type 'LandingPageFieldsFragment'.  TS2339

    13 |   locale: Language
    14 | ): boolean => {
  > 15 |   return Boolean(landingPage.title?.[locale]);
       |                              ^
    16 | };
```
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: