### PR TITLE
TH-928 | Fix canonical URL http -> https

### DIFF
--- a/src/util/getDomainFromRequest.ts
+++ b/src/util/getDomainFromRequest.ts
@@ -5,5 +5,5 @@ export default (req: Request): string => {
   // This will return the host as well as the possible port
   const host = req.get('Host');
 
-  return `${req.protocol}://${host}`;
+  return `https://${host}`;
 };


### PR DESCRIPTION
## Description :sparkles:

Fix canonical URL to have https as protovol

## Issues :bug:

**[TH-928](https://helsinkisolutionoffice.atlassian.net/browse/TH-928):** 

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: