### PR TITLE
Fix resize observer problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # testing
 /coverage
 /screenshot
+/screenshots
 
 # production
 /build

--- a/testcafe/e2e/changeLanguage.ts
+++ b/testcafe/e2e/changeLanguage.ts
@@ -4,9 +4,12 @@ import translationsFi from '../../src/common/translation/i18n/fi.json';
 import translationsSv from '../../src/common/translation/i18n/sv.json';
 import { header } from '../selectors/header';
 import { getPathname } from '../utils/clientUtils';
+import jsErrorHandler from '../utils/jsErrorHandler';
 import { getEnvUrl } from '../utils/settings';
 
-fixture('Landing page').page(getEnvUrl('/fi/home'));
+fixture('Landing page')
+  .clientScripts(jsErrorHandler)
+  .page(getEnvUrl('/fi/home'));
 
 const withinHeader = () => within(screen.getByRole('banner'));
 const withinFooter = () => within(screen.getByRole('contentinfo'));

--- a/testcafe/utils/jsErrorHandler.ts
+++ b/testcafe/utils/jsErrorHandler.ts
@@ -1,0 +1,16 @@
+/**
+ * See more info: https://github.com/DevExpress/testcafe/issues/4857#issuecomment-598775956
+ */
+const jsErrorHandler = (): void => {
+  window.addEventListener('error', (e) => {
+    if (
+      e.message ===
+        'ResizeObserver loop completed with undelivered notifications.' ||
+      e.message === 'ResizeObserver loop limit exceeded'
+    ) {
+      e.stopImmediatePropagation();
+    }
+  });
+};
+
+export default { content: `(${jsErrorHandler.toString()})()` };

--- a/testcafe/utils/jsErrorHandler.ts
+++ b/testcafe/utils/jsErrorHandler.ts
@@ -1,5 +1,8 @@
 /**
- * See more info: https://github.com/DevExpress/testcafe/issues/4857#issuecomment-598775956
+ * ResizeObserver throws error to browser's console. That upsets testcafe that
+ * fails the running test. According to this conversation, ResizeObserver error
+ * can be safely ignored:
+ * https://github.com/DevExpress/testcafe/issues/4857#issuecomment-598775956
  */
 const jsErrorHandler = (): void => {
   window.addEventListener('error', (e) => {


### PR DESCRIPTION
## Description :sparkles:

Fix resize observer problem in testcafe: https://github.com/DevExpress/testcafe/issues/4857#issuecomment-598775956
Originally failed build is here: https://github.com/City-of-Helsinki/events-helsinki-ui/pull/180/checks?check_run_id=1701632369
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: