### PR TITLE
Fix for duplicate event names

### DIFF
--- a/src/util/mockDataUtils.ts
+++ b/src/util/mockDataUtils.ts
@@ -46,11 +46,25 @@ export const fakeEvents = (
 });
 
 export const fakeEvent = (overrides?: Partial<EventDetails>): EventDetails => {
+  const names: string[] = [];
+
+  const uniqueName = (): string => {
+    const name = faker.name.title();
+
+    if (names.includes(name)) {
+      return uniqueName();
+    } else {
+      names.push(name);
+    }
+
+    return name;
+  };
+
   return merge(
     {
       id: `hel:${faker.random.uuid()}`,
       internalId: faker.random.uuid(),
-      name: fakeLocalizedObject(faker.name.title()),
+      name: fakeLocalizedObject(uniqueName()),
       publisher: 'provider:123',
       provider: fakeLocalizedObject(),
       shortDescription: fakeLocalizedObject(),


### PR DESCRIPTION
## Description :sparkles:
Add fix for duplicate event names

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: