### PR TITLE
Th-908: Fix bottom banner top layer image position:

### DIFF
--- a/src/domain/banner/bannerHero/BannerHero.tsx
+++ b/src/domain/banner/bannerHero/BannerHero.tsx
@@ -130,9 +130,8 @@ const BannerHero: React.FC<Props> = ({ banner, location }) => {
           data-testid={testIds.heroTopLayerImage}
           style={{
             backgroundImage: `url(${heroTopLayerImage})`,
-            backgroundPosition: `center calc(100% - ${
-              location === 'top' ? 5.5 : 0
-            }rem)`,
+            // prettier-ignore
+            backgroundPosition: `center calc(100% - ${location === 'top' ? 5.5 : 0}rem)`,
           }}
         />
       )}

--- a/src/domain/banner/bannerHero/BannerHero.tsx
+++ b/src/domain/banner/bannerHero/BannerHero.tsx
@@ -12,10 +12,6 @@ import Container from '../../app/layout/Container';
 import { getBannerFields } from '../bannerUtils';
 import styles from './bannerHero.module.scss';
 
-export const testIds = {
-  content: 'landing-page-hero-content',
-};
-
 const getTextWrapperMaxWidth = (breakpoint: Breakpoint) => {
   switch (breakpoint) {
     case 'md':
@@ -37,9 +33,20 @@ const getTextFontSize = (breakpoint: Breakpoint) => {
 
 interface Props {
   banner: BannerPage;
+  location: 'top' | 'bottom';
 }
 
-const BannerHero: React.FC<Props> = ({ banner }) => {
+export const getTestIds = (
+  location: Props['location']
+): Record<string, string> => ({
+  container: `${location}-banner`,
+  content: `${location}-banner-content`,
+  desktopBackgroundImage: `${location}-desktopBackgroundImage`,
+  mobileBackgroundImage: `${location}-mobileBackgroundImage`,
+  heroTopLayerImage: `${location}-heroTopLayerImage`,
+});
+
+const BannerHero: React.FC<Props> = ({ banner, location }) => {
   const textWrapper = React.useRef<HTMLDivElement>(null);
   const locale = useLocale();
   const breakpoint = useBreakpoint();
@@ -90,14 +97,18 @@ const BannerHero: React.FC<Props> = ({ banner }) => {
     }
   }, [textWrapperWidth, titleAndDescriptionColor]);
 
+  const testIds = getTestIds(location);
+
   return (
     <div
       className={classNames(styles.bannerHero, {
         [styles[`${backgroundColor}BackgroundColor`]]: backgroundColor,
       })}
+      data-testid={testIds.container}
     >
       <div
         className={styles.desktopBackgroundImage}
+        data-testid={testIds.desktopBackgroundImage}
         style={{
           backgroundImage: heroBackgroundImage
             ? `url(${heroBackgroundImage})`
@@ -106,20 +117,25 @@ const BannerHero: React.FC<Props> = ({ banner }) => {
       />
       <div
         className={styles.mobileBackgroundImage}
+        data-testid={testIds.mobileBackgroundImage}
         style={{
           backgroundImage: heroBackgroundImageMobile
             ? `url(${heroBackgroundImageMobile})`
             : 'none',
         }}
       />
-      <div
-        className={styles.image}
-        style={{
-          backgroundImage: heroTopLayerImage
-            ? `url(${heroTopLayerImage})`
-            : 'none',
-        }}
-      />
+      {heroTopLayerImage && (
+        <div
+          className={styles.image}
+          data-testid={testIds.heroTopLayerImage}
+          style={{
+            backgroundImage: `url(${heroTopLayerImage})`,
+            backgroundPosition: `center calc(100% - ${
+              location === 'top' ? 5.5 : 0
+            }rem)`,
+          }}
+        />
+      )}
       <Container>
         <div
           ref={textWrapper}

--- a/src/domain/banner/bannerHero/__tests__/BannerHero.test.tsx
+++ b/src/domain/banner/bannerHero/__tests__/BannerHero.test.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { BannerPageFieldsFragment } from '../../../../generated/graphql';
 import { fakeBanner } from '../../../../util/mockDataUtils';
-import BannerHero, { testIds } from '../BannerHero';
+import BannerHero, { getTestIds } from '../BannerHero';
 const title = 'Banner title';
 const description = 'Banner page description';
 const buttonText = 'Button text';
@@ -16,31 +16,57 @@ const banner = fakeBanner({
 }) as BannerPageFieldsFragment;
 
 test('should be rendered correctly', () => {
-  render(<BannerHero banner={banner} />);
+  render(<BannerHero banner={banner} location="top" />);
 
   expect(screen.getByText(title)).toBeInTheDocument();
   expect(screen.getByText(description)).toBeInTheDocument();
   expect(screen.getByText(buttonText)).toBeInTheDocument();
 });
 
-test('should set text wrapper background color', () => {
+test('should set text wrapper background color and background images', () => {
   render(
     <BannerHero
       banner={{
         ...banner,
         titleAndDescriptionColor: { fi: 'WHITE' },
       }}
+      location="top"
     />
   );
-
+  const testIds = getTestIds('top');
   expect(screen.getByTestId(testIds.content) as HTMLDivElement).toHaveStyle({
     backgroundColor: 'rgba(0, 0, 0, 0.7)',
+  });
+  expect(
+    screen.getByTestId(testIds.desktopBackgroundImage)
+  ).toBeInTheDocument();
+  expect(screen.getByTestId(testIds.mobileBackgroundImage)).toBeInTheDocument();
+  expect(screen.getByTestId(testIds.heroTopLayerImage)).toBeInTheDocument();
+});
+
+test('should set different toplayer image position for top and bottom banner', () => {
+  render(
+    <>
+      <BannerHero banner={banner} location="top" />
+      <BannerHero banner={banner} location="bottom" />
+    </>
+  );
+
+  expect(
+    screen.getByTestId(getTestIds('top').heroTopLayerImage) as HTMLDivElement
+  ).toHaveStyle({
+    backgroundColor: '`center calc(100% - 5.5rem)',
+  });
+  expect(
+    screen.getByTestId(getTestIds('bottom').heroTopLayerImage) as HTMLDivElement
+  ).toHaveStyle({
+    backgroundColor: '`center calc(100% - 0rem)',
   });
 });
 
 test('should open buttonUrl', () => {
   global.open = jest.fn();
-  render(<BannerHero banner={banner} />);
+  render(<BannerHero banner={banner} location="top" />);
 
   userEvent.click(screen.getByRole('button', { name: buttonText }));
   expect(global.open).toBeCalled();

--- a/src/domain/banner/bannerHero/bannerHero.module.scss
+++ b/src/domain/banner/bannerHero/bannerHero.module.scss
@@ -50,7 +50,6 @@
     right: 20%;
     height: 100%;
     width: 24.9375rem;
-    background-position: center calc(100% - 5.5rem);
     background-size: contain;
     background-repeat: no-repeat;
 

--- a/src/domain/landingPage/LandingPage.tsx
+++ b/src/domain/landingPage/LandingPage.tsx
@@ -54,7 +54,7 @@ const Home: React.FC = () => {
           <>
             <LandingPageMeta landingPage={landingPage} />
             {landingPage.topBanner && (
-              <BannerHero banner={landingPage.topBanner} />
+              <BannerHero banner={landingPage.topBanner} location="top" />
             )}
           </>
         )}
@@ -78,7 +78,7 @@ const Home: React.FC = () => {
           </MainContent>
         )}
         {landingPage?.bottomBanner && (
-          <BannerHero banner={landingPage.bottomBanner} />
+          <BannerHero banner={landingPage.bottomBanner} location="bottom" />
         )}
       </LoadingSpinner>
     </PageWrapper>

--- a/src/domain/landingPage/LandingPagePreview.tsx
+++ b/src/domain/landingPage/LandingPagePreview.tsx
@@ -36,7 +36,7 @@ const LandingPagePreview: React.FC = () => {
             <LandingPageMeta landingPage={landingPage} />
             <PreviewBanner />
             {landingPage.topBanner && (
-              <BannerHero banner={landingPage.topBanner} />
+              <BannerHero banner={landingPage.topBanner} location="top" />
             )}
             <MainContent offset={-150}>
               <Container>
@@ -44,7 +44,7 @@ const LandingPagePreview: React.FC = () => {
               </Container>
             </MainContent>
             {landingPage.bottomBanner && (
-              <BannerHero banner={landingPage.bottomBanner} />
+              <BannerHero banner={landingPage.bottomBanner} location="bottom" />
             )}
           </>
         ) : (


### PR DESCRIPTION
## Description :sparkles:
See comment on https://helsinkisolutionoffice.atlassian.net/browse/TH-908 : fix top layer image's position on bottom banner
## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/TH-908 (see comment)
## Testing :alembic:

## Screenshots :camera_flash:
before:
<img width="1287" alt="Screenshot 2021-01-21 at 4 57 28 PM" src="https://user-images.githubusercontent.com/7648194/105368155-e61c2f80-5c09-11eb-98c7-fbc3833fd3a9.png">
after:
<img width="1260" alt="Screenshot 2021-01-21 at 4 56 11 PM" src="https://user-images.githubusercontent.com/7648194/105368068-d00e6f00-5c09-11eb-8971-b1a1a9034166.png">

## Additional notes :spiral_notepad: