### PR TITLE
Th-980: Marketing urls: talviloma

### DIFF
--- a/src/domain/app/routes/LocaleRoutes.tsx
+++ b/src/domain/app/routes/LocaleRoutes.tsx
@@ -71,6 +71,11 @@ const App: FunctionComponent<RouteComponentProps<{
         path={`/${locale}${ROUTES.EVENT_PLACE}`}
         component={EventSearchPageContainer}
       />
+      <Route
+        exact
+        path={`/${locale}${ROUTES.MARKETING_COLLECTION}`}
+        component={CollectionPageContainer}
+      />
       <Route component={NotFound} />
     </Switch>
   );

--- a/src/domain/app/routes/constants.ts
+++ b/src/domain/app/routes/constants.ts
@@ -1,4 +1,7 @@
-import { MAPPED_PLACES } from '../../eventSearch/constants';
+import {
+  MAPPED_PLACES,
+  MARKETING_COLLECTION_SLUGS,
+} from '../../eventSearch/constants';
 
 // Remember also update static urls to updateSitemap
 export const ROUTES = {
@@ -11,4 +14,5 @@ export const ROUTES = {
   HOME: '/home',
   HOME_PREVIEW: '/home/:id',
   EVENT_PLACE: `/:place(${Object.keys(MAPPED_PLACES).join('|')})`,
+  MARKETING_COLLECTION: `/:slug(${MARKETING_COLLECTION_SLUGS.join('|')})`,
 };

--- a/src/domain/collection/__tests__/CollectionPageContainer.test.tsx
+++ b/src/domain/collection/__tests__/CollectionPageContainer.test.tsx
@@ -1,6 +1,7 @@
+import { MockedResponse } from '@apollo/react-testing';
 import { screen, waitFor } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import React from 'react';
+import * as React from 'react';
 
 import translations from '../../../common/translation/i18n/fi.json';
 import {
@@ -20,16 +21,16 @@ const draftRoutes = [
   `${ROUTES.COLLECTION.replace(':slug', collection.slug)}?draft=true`,
 ];
 
-const getMocks = (
+export const getMocks = (
   collectionDetails: CollectionFieldsFragment,
   draft = false
-) => [
+): MockedResponse[] => [
   {
     request: {
       query: CollectionDetailsDocument,
       variables: {
         draft,
-        slug: collection.slug,
+        slug: collectionDetails.slug,
       },
     },
     result: {

--- a/src/domain/collection/collectionCard/__tests__/CollectionCard.test.tsx
+++ b/src/domain/collection/collectionCard/__tests__/CollectionCard.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { ROUTES } from '../../../../domain/app/routes/constants';
 import { CollectionFieldsFragment } from '../../../../generated/graphql';
@@ -28,7 +28,7 @@ test('matches snapshot', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('should hide desciprion', () => {
+test('should hide description', () => {
   render(<CollectionCard collection={collection} size="md" />);
 
   expect(screen.getByText(title)).toBeInTheDocument();

--- a/src/domain/eventSearch/__tests__/contants.test.ts
+++ b/src/domain/eventSearch/__tests__/contants.test.ts
@@ -1,0 +1,8 @@
+import { MAPPED_PLACES, MARKETING_COLLECTION_SLUGS } from '../constants';
+
+it('mapped places and marketing collections should not have same slugs', () => {
+  const intersection = Object.keys(MAPPED_PLACES).filter((value) =>
+    MARKETING_COLLECTION_SLUGS.includes(value)
+  );
+  expect(intersection).toHaveLength(0);
+});

--- a/src/domain/eventSearch/constants.ts
+++ b/src/domain/eventSearch/constants.ts
@@ -123,3 +123,5 @@ export const MAPPED_PLACES: Record<string, string> = {
   vuotalo: 'tprek:7260',
   malmitalo: 'tprek:8740',
 };
+
+export const MARKETING_COLLECTION_SLUGS = ['talviloma'];


### PR DESCRIPTION
## Description :sparkles:
Marketing url functionality + talviloma added as fixed marketing slug
## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/TH-980
## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: