### PR TITLE
PT-981 | Course/Event back button fix

### DIFF
--- a/src/domain/eventSearch/SearchPage.tsx
+++ b/src/domain/eventSearch/SearchPage.tsx
@@ -80,7 +80,8 @@ const SearchPage: React.FC<{
       // Clear eventId value to keep scroll position correctly
       const state = { ...location.state };
       delete state.eventId;
-      history.replace({ state });
+      // location.search seems to reset if not added here (...location)
+      history.replace({ ...location, state });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## Description :sparkles:

- Fix issue where filters would reset when clicking back button in course/event page

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: