### PR TITLE
fix encoding in url paths in browser tests

### DIFF
--- a/browser-tests/utils/url.utils.ts
+++ b/browser-tests/utils/url.utils.ts
@@ -65,7 +65,10 @@ export const getUrlUtils = (t: TestController) => {
       t.ctx.collection = collection;
       await t
         .expect(getPathname())
-        .eql(`/fi/collection/${collection.slug}`, await getErrorMessage(t))
+        .eql(
+          `/fi/collection/${encodeURIComponent(collection.slug)}`,
+          await getErrorMessage(t)
+        )
         .expect(getPageTitle())
         .eql(collection.title.fi, await getErrorMessage(t), { timeout: 10000 });
     },


### PR DESCRIPTION
## Description :sparkles:
Avoid errors like this: https://github.com/City-of-Helsinki/events-helsinki-ui/runs/1862824623?check_suite_focus=true
```
      ------------------------------------------------
      : expected '/fi/collection/tapahtumat-kev%C3%A4t' to deeply equal
      '/fi/collection/tapahtumat-kevät'

      + expected - actual

      -'/fi/collection/tapahtumat-kev%C3%A4t'
      +'/fi/collection/tapahtumat-kevät'


      Browser: Chrome 88.0.4324.104 / Windows 10
      Screenshot:
```
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: