### PR TITLE
TH-1014: Stabilize browser tests

### DIFF
--- a/browser-tests/common.components.ts
+++ b/browser-tests/common.components.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import TestController from 'testcafe';
+
+import { getErrorMessage, screenContext } from './utils/testcafe.utils';
+
+export const getCommonComponents = (t: TestController) => {
+  const screen = screenContext(t);
+  const loadingSpinner = () => {
+    const selectors = {
+      spinner() {
+        return screen.findByTestId('loading-spinner');
+      },
+    };
+    const expectations = {
+      async isNotPresent() {
+        await t
+          .expect(selectors.spinner().exists)
+          .notOk(await getErrorMessage(t));
+      },
+    };
+    return {
+      expectations,
+    };
+  };
+  return {
+    loadingSpinner,
+  };
+};

--- a/browser-tests/event-search/eventSearchPage.testcafe.ts
+++ b/browser-tests/event-search/eventSearchPage.testcafe.ts
@@ -14,7 +14,7 @@ import {
   selectRandomValueFromArray,
   selectRandomValuesFromArray,
 } from '../utils/random.utils';
-import { splitBySentences } from '../utils/regexp.util';
+import { getRandomSentence } from '../utils/regexp.util';
 import { getEnvUrl } from '../utils/settings';
 import { clearContext } from '../utils/testcafe.utils';
 import { getUrlUtils } from '../utils/url.utils';
@@ -62,7 +62,7 @@ test('"click more events" -button works', async (t) => {
 
 test('Search url by event name shows event card data for helsinki event', async () => {
   const [event] = await getHelsinkiEvents();
-  await urlUtils.actions.navigateToSearchUrl(event.name.fi);
+  await urlUtils.actions.navigateToSearchUrl(getRandomSentence(event.name.fi));
   const searchResults = await eventSearchPage.findSearchResultList();
   const eventCard = await searchResults.eventCard(event);
   await eventCard.expectations.eventTimeIsPresent();
@@ -78,9 +78,7 @@ test('Free text search finds event by free text search', async (t) => {
     await testSearchEventByText(t, event, event.name[locale], 'name');
     const randomShortDescriptionSentence =
       event.shortDescription[locale] &&
-      selectRandomValueFromArray(
-        splitBySentences(event.shortDescription[locale])
-      );
+      getRandomSentence(event.shortDescription[locale]);
     await testSearchEventByText(
       t,
       event,
@@ -88,8 +86,7 @@ test('Free text search finds event by free text search', async (t) => {
       'shortDescription'
     );
     const randomDescriptionSentence =
-      event.description[locale] &&
-      selectRandomValueFromArray(splitBySentences(event.description[locale]));
+      event.description[locale] && getRandomSentence(event.description[locale]);
     await testSearchEventByText(
       t,
       event,
@@ -112,7 +109,7 @@ test('Free text search finds event by free text search', async (t) => {
     await testSearchEventByText(
       t,
       event,
-      randomKeyword.name[locale],
+      getRandomSentence(randomKeyword.name[locale]),
       'keywords'
     );
   }

--- a/browser-tests/utils/regexp.util.ts
+++ b/browser-tests/utils/regexp.util.ts
@@ -1,3 +1,5 @@
+import { selectRandomValueFromArray } from './random.utils';
+
 export const regExpEscaped = (text: string, flags?: string): RegExp => {
   return new RegExp(escapeRegExp(text), flags);
 };
@@ -11,3 +13,7 @@ export const splitBySentences = (text: string): string[] =>
     .split('____')
     .map((s) => s.trim())
     .filter((s) => /[^.,!?()]+/.test(s));
+
+export const getRandomSentence = (text: string): string => {
+  return selectRandomValueFromArray(splitBySentences(text));
+};

--- a/browser-tests/utils/url.utils.ts
+++ b/browser-tests/utils/url.utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import TestController, { ClientFunction } from 'testcafe';
 
+import { getCommonComponents } from '../common.components';
 import {
   BannerPageFieldsFragment,
   CollectionFieldsFragment,
@@ -14,6 +15,10 @@ const getUrl = ClientFunction(() => document.location.href);
 const getPageTitle = ClientFunction(() => document.title);
 
 export const getUrlUtils = (t: TestController) => {
+  const pageIsLoaded = async () => {
+    await getCommonComponents(t).loadingSpinner().expectations.isNotPresent();
+  };
+
   const actions = {
     async navigateToLandingPage() {
       await t.navigateTo(getEnvUrl(`/fi/home`));
@@ -37,21 +42,26 @@ export const getUrlUtils = (t: TestController) => {
       t.ctx.expectedEvent = event;
       await t
         .expect(getPathname())
-        .eql(`/fi/event/${event.id}`, await getErrorMessage(t))
+        .eql(`/fi/event/${event.id}`, await getErrorMessage(t));
+      await pageIsLoaded();
+      await t
         .expect(getPageTitle())
         .eql(event.name.fi, await getErrorMessage(t));
     },
     async urlChangedToEventSearchPage() {
+      await t.expect(getPathname()).eql(`/fi/events`, await getErrorMessage(t));
+
+      await pageIsLoaded();
       await t
-        .expect(getPathname())
-        .eql(`/fi/events`, await getErrorMessage(t))
         .expect(getPageTitle())
         .eql('Tapahtumat', await getErrorMessage(t));
     },
     async urlChangedToRecommendationsPage() {
       await t
         .expect(getPathname())
-        .eql(`/fi/collections`, await getErrorMessage(t))
+        .eql(`/fi/collections`, await getErrorMessage(t));
+      await pageIsLoaded();
+      await t
         .expect(getPageTitle())
         .eql('Tapahtumat', await getErrorMessage(t));
     },


### PR DESCRIPTION
## Description :sparkles:
Browser tests fails occasionally for two reasons:
- 1:  https://helsinkisolutionoffice.atlassian.net/browse/TH-1014 : Event cannot be found by searching tag name with brackets. This can be fixed from our side by stripping out brackets and search by either the part outside the brackets or inside the brackets: For example if keyword is: `Play (Children games)`, let's search either by `Play` or `Children games`. This failure has happened also on event title search, so let's use this random sentence pick in every free text search.
- 2: Sometimes page title says that collection is still loading, example failure: https://github.com/City-of-Helsinki/events-helsinki-ui/pull/180/checks?check_run_id=1910892461
```
: expected 'Ladataan tapahtumaa... - Tapahtumat' to deeply equal
      'Maahanmuuttajien ohjausta asukastalo Saunabaarissa'

      + expected - actual

      -'Ladataan tapahtumaa... - Tapahtumat'
      +'Maahanmuuttajien ohjausta asukastalo Saunabaarissa'
```
  This is fixed by always waiting for loading spinner to vanish when url has changed.
      
## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/TH-1014
## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: