### PR TITLE
TH-1022 | Add scroll restoration to collection page

### DIFF
--- a/src/domain/app/scrollToTop/ScrollToTop.tsx
+++ b/src/domain/app/scrollToTop/ScrollToTop.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router';
+import { useHistory, useLocation } from 'react-router';
 
 import isClient from '../../../util/isClient';
 
@@ -12,12 +12,13 @@ import isClient from '../../../util/isClient';
  */
 const ScrollToTop = (): null => {
   const { pathname } = useLocation();
+  const { action } = useHistory();
 
   React.useEffect(() => {
-    if (isClient) {
+    if (isClient && action === 'PUSH') {
       window.scrollTo(0, 0);
     }
-  }, [pathname]);
+  }, [action, pathname]);
 
   return null;
 };

--- a/src/domain/collection/CollectionPageContainer.tsx
+++ b/src/domain/collection/CollectionPageContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useParams } from 'react-router';
+import { useHistory, useLocation, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 
 import ErrorHero from '../../common/components/error/ErrorHero';
@@ -14,6 +14,7 @@ import useLocale from '../../hooks/useLocale';
 import MainContent from '../app/layout/MainContent';
 import PageWrapper from '../app/layout/PageWrapper';
 import { ROUTES } from '../app/routes/constants';
+import { getLargeEventCardId } from '../event/EventUtils';
 import CollectionHero from './collectionHero/CollectionHero';
 import styles from './collectionPage.module.scss';
 import CollectionPageMeta from './collectionPageMeta/CollectionPageMeta';
@@ -37,6 +38,8 @@ type Error = {
 const CollectionPageContainer: React.FC = () => {
   const { search } = useLocation();
   const params = useParams<RouteParams>();
+  const location = useLocation();
+  const history = useHistory();
 
   const { t } = useTranslation();
   const locale = useLocale();
@@ -81,6 +84,24 @@ const CollectionPageContainer: React.FC = () => {
 
     return null;
   };
+
+  const scrollToEventCard = (id: string) => {
+    document
+      .getElementById(id)
+      ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  };
+
+  // Scroll back to correct event card (event tat user is coming back from)
+  React.useEffect(() => {
+    if (location.state?.eventId) {
+      const cardId = getLargeEventCardId(location.state.eventId);
+      scrollToEventCard(cardId);
+      // Clear eventId value to keep scroll position correctly
+      const state = { ...location.state };
+      delete state.eventId;
+      history.replace({ ...location, state });
+    }
+  }, [history, location]);
 
   const renderErrorHero = (error: Error) => {
     return (

--- a/src/domain/collection/CollectionPageContainer.tsx
+++ b/src/domain/collection/CollectionPageContainer.tsx
@@ -91,7 +91,7 @@ const CollectionPageContainer: React.FC = () => {
       ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
   };
 
-  // Scroll back to correct event card (event tat user is coming back from)
+  // Scroll back to correct event card (event that user is coming back from)
   React.useEffect(() => {
     if (location.state?.eventId) {
       const cardId = getLargeEventCardId(location.state.eventId);

--- a/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
+++ b/src/domain/event/eventInfo/__tests__/OtherEventTimes.test.tsx
@@ -80,8 +80,6 @@ const secondPageLoadThrowsErrorMock = createOtherEventTimesRequestThrowsErrorMoc
 
 const defaultMocks = [firstLoadMock, secondLoadMock];
 
-console.log(defaultMocks);
-
 afterAll(() => {
   clear();
 });


### PR DESCRIPTION
## Description :sparkles:

- Add scroll restoration to collection page

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

I spent quite a bit of time investigating how scroll positions could be handled and if we could have some reusable logic here but ended up with simple solution for now... If someone has good suggestions how to could be handled lets hear them :)