### PR TITLE
TH-861 | Fix header link

### DIFF
--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -258,7 +258,7 @@
       "sv": "På svenska"
     },
     "searchCollections": "Suosittelemme",
-    "searchEvents": "Etsi tapahtumia",
+    "searchEvents": "Tapahtumat",
     "searchHobbies": "Harrastukset"
   },
   "home": {


### PR DESCRIPTION
## Description :sparkles:

- Fix header navigation label in finnish from 'etsi tapahtumia' to 'tapahtumat'

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: