### PR TITLE
TH-956 | Add external icons

### DIFF
--- a/src/common/components/link/Link.tsx
+++ b/src/common/components/link/Link.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { IconAngleRight } from 'hds-react';
+import { IconAngleRight, IconLinkExternal } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink, LinkProps } from 'react-router-dom';
@@ -36,7 +36,7 @@ const Link: React.FC<Props> = ({
     <a href={to} rel="noopener noreferrer" target="_blank" {...commonProps}>
       {children}
       <SrOnly>{t('commons.srOnly.opensInANewTab')}</SrOnly>
-      <IconAngleRight aria-hidden />
+      <IconLinkExternal aria-hidden />
     </a>
   ) : (
     <RouterLink to={to} {...commonProps} {...rest}>

--- a/src/domain/event/eventCard/LargeEventCard.tsx
+++ b/src/domain/event/eventCard/LargeEventCard.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Button } from 'hds-react';
+import { Button, IconLinkExternal } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router';
@@ -143,6 +143,7 @@ const LargeEventCard: React.FC<Props> = ({ event, eventType = 'event' }) => {
             {showBuyButton && (
               <Button
                 aria-label={t('event.eventCard.ariaLabelBuyTickets')}
+                iconRight={<IconLinkExternal aria-hidden />}
                 fullWidth
                 onClick={goToBuyTicketsPage}
                 size="small"

--- a/src/domain/event/eventContent/__tests__/EventContent.test.tsx
+++ b/src/domain/event/eventContent/__tests__/EventContent.test.tsx
@@ -55,10 +55,6 @@ it('should render event content fields', async () => {
       role: 'link',
       name: `${translations.event.location.openMap} ${translations.commons.srOnly.opensInANewTab}`,
     },
-    {
-      role: 'link',
-      name: `${translations.event.location.directionsHSL} ${translations.commons.srOnly.opensInANewTab}`,
-    },
   ];
   itemsByRole.forEach(({ role, name }) => {
     expect(screen.queryByRole(role, { name })).toBeInTheDocument();
@@ -78,6 +74,10 @@ it('should render event content fields', async () => {
     {
       role: 'link',
       name: `${translations.event.location.directionsGoogle} ${translations.commons.srOnly.opensInANewTab}`,
+    },
+    {
+      role: 'link',
+      name: `${translations.event.location.directionsHSL} ${translations.commons.srOnly.opensInANewTab}`,
     },
   ];
 

--- a/src/domain/event/eventHero/EventHero.tsx
+++ b/src/domain/event/eventHero/EventHero.tsx
@@ -1,5 +1,11 @@
 import classNames from 'classnames';
-import { Button, IconArrowLeft, IconLocation, IconTicket } from 'hds-react';
+import {
+  Button,
+  IconArrowLeft,
+  IconLinkExternal,
+  IconLocation,
+  IconTicket,
+} from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -164,6 +170,7 @@ const EventHero: React.FC<Props> = ({ event, eventType, superEvent }) => {
                     <Button
                       aria-label={t('event.hero.ariaLabelBuyTickets')}
                       onClick={goToBuyTicketsPage}
+                      iconRight={<IconLinkExternal aria-hidden />}
                       variant="success"
                     >
                       {t('event.hero.buttonBuyTickets')}

--- a/src/domain/event/eventLocation/EventLocation.tsx
+++ b/src/domain/event/eventLocation/EventLocation.tsx
@@ -1,4 +1,4 @@
-import { IconAngleRight, IconLinkExternal, IconLocation } from 'hds-react';
+import { IconLinkExternal, IconLocation } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -62,7 +62,7 @@ const EventLocation: React.FC<Props> = ({ event }) => {
       >
         {t('event.location.directionsGoogle')}
         <SrOnly>{t('commons.srOnly.opensInANewTab')}</SrOnly>
-        <IconAngleRight aria-hidden />
+        <IconLinkExternal size="xs" aria-hidden />
       </a>
       <a
         className={styles.directionsLink}
@@ -70,9 +70,9 @@ const EventLocation: React.FC<Props> = ({ event }) => {
         rel="noopener noreferrer"
         target="_blank"
       >
-        <SrOnly>{t('commons.srOnly.opensInANewTab')}</SrOnly>
         {t('event.location.directionsHSL')}
-        <IconAngleRight aria-hidden />
+        <SrOnly>{t('commons.srOnly.opensInANewTab')}</SrOnly>
+        <IconLinkExternal size="xs" aria-hidden />
       </a>
     </div>
   );


### PR DESCRIPTION
## Description :sparkles:

- Add external icon to external links

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

<img width="447" alt="Screenshot 2021-03-03 at 15 34 50" src="https://user-images.githubusercontent.com/15219142/109813526-2671c300-7c36-11eb-95b7-7b03faf855e0.png">
<img width="843" alt="Screenshot 2021-03-03 at 15 34 42" src="https://user-images.githubusercontent.com/15219142/109813531-283b8680-7c36-11eb-8818-6be0cdf88f81.png">
<img width="1200" alt="Screenshot 2021-03-03 at 15 34 33" src="https://user-images.githubusercontent.com/15219142/109813534-296cb380-7c36-11eb-86b7-4efda3e7676f.png">


## Additional notes :spiral_notepad: