### PR TITLE
TH-1006: Add local event time to event hero

### DIFF
--- a/src/domain/event/eventHero/EventHero.tsx
+++ b/src/domain/event/eventHero/EventHero.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import {
   Button,
   IconArrowLeft,
+  IconCalendarClock,
   IconLinkExternal,
   IconLocation,
   IconTicket,
@@ -157,6 +158,27 @@ const EventHero: React.FC<Props> = ({ event, eventType, superEvent }) => {
                       showLocationName={true}
                     />
                   </InfoWithIcon>
+                </Visible>
+                <Visible above="sm" className={styles.start}>
+                  {superEvent?.status === 'pending' ? (
+                    <SkeletonLoader />
+                  ) : (
+                    (startTime !== eventStartTime ||
+                      endTime !== eventEndTime) && (
+                      <InfoWithIcon
+                        icon={<IconCalendarClock aria-hidden />}
+                        title={''}
+                      >
+                        {getDateRangeStr({
+                          start: eventStartTime || '',
+                          end: eventEndTime,
+                          locale,
+                          includeTime: true,
+                          timeAbbreviation: t('commons.timeAbbreviation'),
+                        })}
+                      </InfoWithIcon>
+                    )
+                  )}
                 </Visible>
                 {eventPriceText && (
                   <Visible above="sm" className={styles.price}>

--- a/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -209,7 +209,7 @@ test('should have event dates when super event is not defined', () => {
   expect(screen.getByText(dateStr)).toBeInTheDocument();
 });
 
-test('should have super event dates when super event is defined', () => {
+test('should have super event dates and event dates when super event is defined', () => {
   const mockEvent = getFakeEvent();
   const mockSuperEvent = getFakeEvent({
     startTime: '2020-06-22T07:00:00.000000Z',
@@ -231,4 +231,14 @@ test('should have super event dates when super event is defined', () => {
     timeAbbreviation: translations.commons.timeAbbreviation,
   });
   expect(screen.getByText(superDateStr)).toBeInTheDocument();
+
+  const dateStr = getDateRangeStr({
+    start: mockEvent.startTime,
+    end: mockEvent.endTime,
+    locale: 'fi',
+    includeTime: true,
+    timeAbbreviation: translations.commons.timeAbbreviation,
+  });
+
+  expect(screen.getByText(dateStr)).toBeInTheDocument();
 });

--- a/src/domain/event/eventHero/__tests__/EventHero.test.tsx
+++ b/src/domain/event/eventHero/__tests__/EventHero.test.tsx
@@ -194,7 +194,7 @@ test('Register button should be visible and clickable', () => {
   expect(global.open).toBeCalledWith(registrationUrl);
 });
 
-test('should have event dates when super event is not defined', () => {
+test('should show event dates when super event is not defined', () => {
   const mockEvent = getFakeEvent();
 
   render(<EventHero event={mockEvent} eventType="course" />);
@@ -209,7 +209,7 @@ test('should have event dates when super event is not defined', () => {
   expect(screen.getByText(dateStr)).toBeInTheDocument();
 });
 
-test('should have super event dates and event dates when super event is defined', () => {
+test('should show event dates and super event dates if super event is defined', () => {
   const mockEvent = getFakeEvent();
   const mockSuperEvent = getFakeEvent({
     startTime: '2020-06-22T07:00:00.000000Z',

--- a/src/domain/event/eventHero/eventHero.module.scss
+++ b/src/domain/event/eventHero/eventHero.module.scss
@@ -107,16 +107,20 @@ $logoWidth: 5.5rem;
       order: 5;
     }
 
-    .price {
+    .start {
       order: 6;
     }
 
-    .buyButtonWrapper {
+    .price {
       order: 7;
     }
 
-    .registrationButtonWrapper {
+    .buyButtonWrapper {
       order: 8;
+    }
+
+    .registrationButtonWrapper {
+      order: 9;
     }
   }
 


### PR DESCRIPTION
## Description :sparkles:
Adds local event (type course) time to the hero under the location, when main event date is defined.