### PR TITLE
Fix browser tests on events-helsinki-2 branch + removed doubled text from header

### DIFF
--- a/browser-tests/event-search/eventSearchPage.testcafe.ts
+++ b/browser-tests/event-search/eventSearchPage.testcafe.ts
@@ -119,12 +119,14 @@ test('Free text search finds event by free text search', async (t) => {
       event.location.name[locale],
       'location'
     );
-    await testSearchEventByText(
-      t,
-      event,
-      event.location.streetAddress[locale],
-      'location'
-    );
+    if (!isInternetEvent(event)) {
+      await testSearchEventByText(
+        t,
+        event,
+        event.location.streetAddress[locale],
+        'location'
+      );
+    }
     const randomKeyword = selectRandomValueFromArray(event.keywords);
     await testSearchEventByText(
       t,

--- a/browser-tests/header/header.components.ts
+++ b/browser-tests/header/header.components.ts
@@ -85,7 +85,7 @@ export const findHeader = async (
       },
       courseSearchTab() {
         return withinHeader().findByRole('link', {
-          name: getTranslations(t.ctx.expectedLanguage).header.searchHobbies,
+          name: getTranslations(currentLang).header.searchHobbies,
         });
       },
       recommendationsTab() {

--- a/browser-tests/utils/url.utils.ts
+++ b/browser-tests/utils/url.utils.ts
@@ -62,7 +62,7 @@ export const getUrlUtils = (t: TestController) => {
         .eql(`/fi/courses`, await getErrorMessage(t));
       await t
         .expect(getPageTitle())
-        .eql('Tapahtumat', await getErrorMessage(t)); // TODO: perhaps wrong title?
+        .eql('Tapahtumat Helsinki', await getErrorMessage(t)); // TODO: perhaps wrong title?
     },
     async urlChangedToRecommendationsPage() {
       await t

--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -73,8 +73,6 @@ const Header: React.FC<HeaderProps> = ({ menuOpen, onMenuToggle }) => {
       skipToContentLabel={t('header.skipToContentLabel')}
       className={styles.navigation}
       onTitleClick={goToPage(`/${locale}${ROUTES.HOME}`)}
-      title={t('appName')}
-      titleUrl={`/${locale}${ROUTES.HOME}`}
       logoLanguage={logoLang}
     >
       <Navigation.Row variant="inline">

--- a/src/domain/app/header/__tests__/Header.test.tsx
+++ b/src/domain/app/header/__tests__/Header.test.tsx
@@ -42,9 +42,9 @@ test('should show navigation links and click should route to correct pages', asy
   const { history } = renderComponent();
 
   const eventsUrl = `/fi${ROUTES.EVENTS}`;
-  const eventLink = screen.queryAllByRole('link', {
+  const eventLink = screen.queryByRole('link', {
     name: translations.header.searchEvents,
-  })[1];
+  });
   expect(eventLink).toBeInTheDocument();
   userEvent.click(eventLink);
   expect(history.location.pathname).toBe(eventsUrl);

--- a/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`matches snapshot 1`] = `
 <header
-  class="Navigation-module_header__2HNOX Navigation-module_theme-light__36nmi navigation"
+  class="Navigation-module_header__2HNOX Navigation-module_noTitle__3qbce Navigation-module_theme-light__36nmi navigation"
 >
   <a
     class="Navigation-module_skipToContent__2p54x"
@@ -18,7 +18,7 @@ exports[`matches snapshot 1`] = `
     >
       <a
         class="Navigation-module_title__3zRBe"
-        href="/sv/home"
+        tabindex="0"
       >
         <svg
           aria-hidden="true"
@@ -32,9 +32,6 @@ exports[`matches snapshot 1`] = `
             fill="currentColor"
           />
         </svg>
-        <span>
-          Tapahtumat
-        </span>
       </a>
       <div
         class="Navigation-module_headerContent__3zHbK"

--- a/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`matches snapshot 1`] = `
 <div>
   <header
-    class="Navigation-module_header__2HNOX Navigation-module_theme-light__36nmi navigation"
+    class="Navigation-module_header__2HNOX Navigation-module_noTitle__3qbce Navigation-module_theme-light__36nmi navigation"
   >
     <a
       class="Navigation-module_skipToContent__2p54x"
@@ -19,7 +19,7 @@ exports[`matches snapshot 1`] = `
       >
         <a
           class="Navigation-module_title__3zRBe"
-          href="/fi/home"
+          tabindex="0"
         >
           <svg
             aria-hidden="true"
@@ -37,9 +37,6 @@ exports[`matches snapshot 1`] = `
               fill="currentColor"
             />
           </svg>
-          <span>
-            Tapahtumat
-          </span>
         </a>
         <div
           class="Navigation-module_headerContent__3zHbK"


### PR DESCRIPTION
## Description :sparkles:
- fix browser tests
- removed doubled text from header (see screenshot)
## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:
<img width="780" alt="Screenshot 2021-03-05 at 1 13 30 PM" src="https://user-images.githubusercontent.com/7648194/110111887-b0966480-7db9-11eb-98e1-7008dc2e5ed5.png">

## Additional notes :spiral_notepad: