### PR TITLE
Moved BannerHero props to utils.

### DIFF
--- a/src/domain/banner/bannerHero/BannerHero.tsx
+++ b/src/domain/banner/bannerHero/BannerHero.tsx
@@ -4,24 +4,19 @@ import capitalize from 'lodash/capitalize';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { BannerPage } from '../../../generated/graphql';
 import useBreakpoint from '../../../hooks/useBreakpoint';
 import useLocale from '../../../hooks/useLocale';
 import useTextWrapperWidth from '../../../hooks/useTextWrapperWidth';
 import Container from '../../app/layout/Container';
 import { contentBackgroundColorMap } from '../bannerConstants';
 import {
+  BannerHeroProps,
   getBannerContentTextFontSize,
   getBannerContentTextWrapperMaxWidth,
   getBannerFields,
   getTestIds,
 } from '../bannerUtils';
 import styles from './bannerHero.module.scss';
-
-export type BannerHeroProps = {
-  banner: BannerPage;
-  location: 'top' | 'bottom';
-};
 
 const BannerHero: React.FC<BannerHeroProps> = ({ banner, location }) => {
   const textWrapper = React.useRef<HTMLDivElement>(null);

--- a/src/domain/banner/bannerUtils.ts
+++ b/src/domain/banner/bannerUtils.ts
@@ -1,7 +1,11 @@
 import { BannerPage, Maybe } from '../../generated/graphql';
 import { Breakpoint, LandingPageTextColor, Language } from '../../types';
 import { BANNER_SOME_IMAGE } from './bannerConstants';
-import { BannerHeroProps } from './bannerHero/BannerHero';
+
+export type BannerHeroProps = {
+  banner: BannerPage;
+  location: 'top' | 'bottom';
+};
 
 export const getTestIds = (
   location: BannerHeroProps['location']


### PR DESCRIPTION
TH-1069. TestCafe imported source code in wrong order. Moved BannerHero props to utils. Utils should not import jsx-component.
