### PR TITLE
TH-957: Fix Autosuggestion Box Padding on mobile

### DIFF
--- a/src/common/components/search/autosuggestMenu.module.scss
+++ b/src/common/components/search/autosuggestMenu.module.scss
@@ -1,3 +1,5 @@
+@import 'layout';
+
 .autosuggestMenu {
   --border-color-option: #f9f9f9;
 
@@ -11,6 +13,9 @@
 
   .title {
     padding: var(--spacing-s);
+    @include respond-below(sm) {
+      padding: var(--spacing-3-xs);
+    }
     text-align: center;
     color: var(--color-black-50);
     font-weight: 500;
@@ -57,6 +62,9 @@
       cursor: pointer;
       padding: var(--spacing-s) var(--spacing-m);
       color: var(--color-black);
+      @include respond-below(sm) {
+        padding: var(--spacing-3-xs) var(--spacing-m);
+      }
     }
   }
 


### PR DESCRIPTION
## Description :sparkles:
TODO: Check usage of hds component

On front page screen the search input's autosuggestions box is completely hidden under android mobile keyboard. Let's fix this by making less padding between list items. At least few first items should be now visible. 
## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/TH-957
## Testing :alembic:
 This affects everywhere where input has autosuggestions, these all places should be tested. 
 If you have Android (or some other) phone, you perhaps can open the deployed site with it: http://events-helsinki-ui-th-957-fix-autosuggest-df.test.kuva.hel.ninja/
## Screenshots :camera_flash:
<img width="1079" alt="Screenshot 2021-03-24 at 9 30 31 AM" src="https://user-images.githubusercontent.com/7648194/112271478-a6160f00-8c83-11eb-98bb-b2ea2e637c80.png">

## Additional notes :spiral_notepad: