### PR TITLE
TH-1059 | Update influence keyword set

### DIFF
--- a/src/domain/eventSearch/__tests__/utils.test.ts
+++ b/src/domain/eventSearch/__tests__/utils.test.ts
@@ -73,7 +73,9 @@ describe('getEventSearchVariables function', () => {
       ...defaultParams,
       params: new URLSearchParams(`?categories=${EVENT_CATEGORIES.INFLUENCE}`),
     });
-    expect(keyword4.join(',')).toContain('yso:p1657,yso:p10727');
+    expect(keyword4.join(',')).toContain(
+      'yso:p1657,yso:p742,yso:p5164,yso:p8268,yso:p15882,yso:p15292'
+    );
 
     const { keywordOrSet1: keyword5 } = getEventSearchVariables({
       ...defaultParams,

--- a/src/domain/eventSearch/constants.ts
+++ b/src/domain/eventSearch/constants.ts
@@ -132,7 +132,11 @@ export const CULTURE_KEYWORDS = [
 
 export const INFLUENCE_KEYWORDS = [
   'yso:p1657', // Vaikuttaminen
-  'yso:p10727', // Osallistuminen
+  'yso:p742', // Demokratia
+  'yso:p5164', // Osallisuus
+  'yso:p8268', // Kaavoitus
+  'yso:p15882', // Asemakaavoitus
+  'yso:p15292', // Kaupunkipolitiikka
 ];
 
 export const MUSEUM_KEYWORDS = [


### PR DESCRIPTION
## Description :sparkles:

- Update keyword mapping of "Osallistu ja vaikuta" category

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: