### PR TITLE
quick fix for click more events - browser test

### DIFF
--- a/browser-tests/event-search/eventSearchPage.components.ts
+++ b/browser-tests/event-search/eventSearchPage.components.ts
@@ -167,9 +167,9 @@ export const getEventSearchPage = (t: TestController) => {
         keywords,
       } = getEventFields(event, 'fi');
       const eventCard = () => {
-        return withinSearchResultList().findByTestId(event.id);
+        return withinSearchResultList().queryByTestId(event.id);
       };
-      const withinEventCard = () => within(screen.getByTestId(event.id));
+      const withinEventCard = () => within(screen.queryByTestId(event.id));
 
       if (searchedField) {
         setDataToPrintOnFailure(

--- a/browser-tests/event-search/eventSearchPage.components.ts
+++ b/browser-tests/event-search/eventSearchPage.components.ts
@@ -24,7 +24,10 @@ import {
 export const getEventSearchPage = (t: TestController) => {
   const within = withinContext(t);
   const screen = screenContext(t);
-  const commonComponents = getCommonComponents(t);
+  const pageIsLoaded = async () =>
+    await getCommonComponents(t)
+      .loadingSpinner()
+      .expectations.isNotPresent({ timeout: 20000 });
   const findSearchBanner = async () => {
     await t
       .expect(screen.findByTestId('searchContainer').exists)
@@ -147,6 +150,7 @@ export const getEventSearchPage = (t: TestController) => {
     const actions = {
       async clickShowMoreEventsButton() {
         await t.click(selectors.clickMoreButton());
+        await pageIsLoaded();
       },
     };
     const eventCard = async (
@@ -167,9 +171,9 @@ export const getEventSearchPage = (t: TestController) => {
         keywords,
       } = getEventFields(event, 'fi');
       const eventCard = () => {
-        return withinSearchResultList().queryByTestId(event.id);
+        return withinSearchResultList().getAllByTestId(event.id).nth(0);
       };
-      const withinEventCard = () => within(screen.queryByTestId(event.id));
+      const withinEventCard = () => within(eventCard());
 
       if (searchedField) {
         setDataToPrintOnFailure(
@@ -178,9 +182,7 @@ export const getEventSearchPage = (t: TestController) => {
           getExpectedEventContext(event, searchedField)
         );
       }
-      await commonComponents
-        .loadingSpinner()
-        .expectations.isNotPresent({ timeout: 20000 });
+      await pageIsLoaded();
       await t.expect(eventCard().exists).ok(await getErrorMessage(t));
 
       const selectors = {


### PR DESCRIPTION
quick fix for click more events -test. It's not perfect solution a it hides the problem but at least we get the tests green and less spam

## Description :sparkles:

## Issues :bug:

## Testing :alembic:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad: