### PR TITLE
The division selector is now visible in course search.

### DIFF
--- a/src/domain/courseSearch/Search.tsx
+++ b/src/domain/courseSearch/Search.tsx
@@ -81,9 +81,6 @@ const Search: React.FC<Props> = ({ scrollToResultList }) => {
 
   const { alsoOngoingCourses, isFree } = getSearchFilters(searchParams);
 
-  //th-1040: temporary
-  const showDivisions = false;
-
   const searchFilters = {
     alsoOngoingCourses,
     categories: selectedCategories,
@@ -292,24 +289,23 @@ const Search: React.FC<Props> = ({ scrollToResultList }) => {
                   toggleIsCustomDate={toggleIsCustomDate}
                 />
               </div>
-              {showDivisions && (
-                <div>
-                  <MultiSelectDropdown
-                    checkboxName="divisionOptions"
-                    icon={<IconLocation aria-hidden />}
-                    inputValue={divisionInput}
-                    name="division"
-                    onChange={setSelectedDivisions}
-                    options={divisionOptions}
-                    selectAllText={t('eventSearch.search.selectAllDivisions')}
-                    setInputValue={setDivisionInput}
-                    showSearch={true}
-                    showSelectAll={true}
-                    title={t('eventSearch.search.titleDropdownDivision')}
-                    value={selectedDivisions}
-                  />
-                </div>
-              )}
+
+              <div>
+                <MultiSelectDropdown
+                  checkboxName="divisionOptions"
+                  icon={<IconLocation aria-hidden />}
+                  inputValue={divisionInput}
+                  name="division"
+                  onChange={setSelectedDivisions}
+                  options={divisionOptions}
+                  selectAllText={t('eventSearch.search.selectAllDivisions')}
+                  setInputValue={setDivisionInput}
+                  showSearch={true}
+                  showSelectAll={true}
+                  title={t('eventSearch.search.titleDropdownDivision')}
+                  value={selectedDivisions}
+                />
+              </div>
 
               <div>
                 <RangeDropdown

--- a/src/domain/courseSearch/__tests__/CourseSearchPageContainer.test.tsx
+++ b/src/domain/courseSearch/__tests__/CourseSearchPageContainer.test.tsx
@@ -259,12 +259,11 @@ it('renders title and search fields', async () => {
     })
   ).toBeInTheDocument();
 
-  //th-1040: temporary
-  /*expect(
+  expect(
     screen.getByRole('button', {
       name: translations.eventSearch.search.titleDropdownDivision,
     })
-  ).toBeInTheDocument();*/
+  ).toBeInTheDocument();
 
   expect(screen.getByText(/jazz/i)).toBeInTheDocument();
 });
@@ -291,12 +290,11 @@ it('initializes search fields correctly from query', async () => {
     })
   ).toHaveTextContent('Huomenna');
 
-  //th-1040: temporary
-  /*expect(
+  expect(
     screen.getByRole('button', {
       name: translations.eventSearch.search.titleDropdownDivision,
     })
-  ).toHaveTextContent(/Alppiharju \+ 1/i);*/
+  ).toHaveTextContent(/Alppiharju \+ 1/i);
 
   expect(
     screen.getByRole('button', {


### PR DESCRIPTION
TH-1111. Removed a feature setting that was left from TH-1040 in order to set the division selector visible.

NOTE: This pull request is left as a draft, because it needs LinkedEvents v2 setupped. 