### PR TITLE
Added an util that resolves event type and can be used by collections EventList.

### DIFF
--- a/browser-tests/utils/generated/graphql.ts
+++ b/browser-tests/utils/generated/graphql.ts
@@ -63,7 +63,6 @@ export type CollectionDetails = {
   description?: Maybe<LocalizedObject>,
   draftTitle?: Maybe<Scalars['String']>,
   eventListQuery?: Maybe<LocalizedObject>,
-  courseListQuery?: Maybe<LocalizedObject>,
   eventListTitle?: Maybe<LocalizedObject>,
   expireAt?: Maybe<Scalars['String']>,
   expired?: Maybe<Scalars['Boolean']>,

--- a/src/domain/collection/eventList/EventList.tsx
+++ b/src/domain/collection/eventList/EventList.tsx
@@ -32,7 +32,7 @@ const EventList: React.FC<Props> = ({ collection }) => {
     collection,
     locale
   );
-  const eventType = getEventTypeFromRouteUrl(eventListQuery);
+  const eventType = getEventTypeFromRouteUrl(eventListQuery, locale);
   const searchParams = new URLSearchParams(
     eventListQuery ? new URL(eventListQuery).search : ''
   );
@@ -44,13 +44,13 @@ const EventList: React.FC<Props> = ({ collection }) => {
       params: searchParams,
       sortOrder: EVENT_SORT_OPTIONS.END_TIME,
       superEventType: ['umbrella', 'none'],
-      eventType: 'event',
+      eventType: eventType ?? 'event',
     });
-  }, [locale, searchParams]);
+  }, [eventType, locale, searchParams]);
 
   const { data: eventsData, fetchMore, loading } = useEventListQuery({
     notifyOnNetworkStatusChange: true,
-    skip: !eventListQuery,
+    skip: !eventListQuery || !eventType,
     ssr: false,
     variables: eventFilters,
   });

--- a/src/domain/collection/eventList/EventList.tsx
+++ b/src/domain/collection/eventList/EventList.tsx
@@ -11,7 +11,11 @@ import useLocale from '../../../hooks/useLocale';
 import Container from '../../app/layout/Container';
 import EventSearchList from '../../eventList/EventList';
 import { EVENT_SORT_OPTIONS, PAGE_SIZE } from '../../eventSearch/constants';
-import { getEventSearchVariables, getNextPage } from '../../eventSearch/utils';
+import {
+  getEventSearchVariables,
+  getEventTypeFromRouteUrl,
+  getNextPage,
+} from '../../eventSearch/utils';
 import { getCollectionFields } from '../CollectionUtils';
 import styles from './eventList.module.scss';
 
@@ -28,6 +32,7 @@ const EventList: React.FC<Props> = ({ collection }) => {
     collection,
     locale
   );
+  const eventType = getEventTypeFromRouteUrl(eventListQuery);
   const searchParams = new URLSearchParams(
     eventListQuery ? new URL(eventListQuery).search : ''
   );

--- a/src/domain/eventSearch/utils.tsx
+++ b/src/domain/eventSearch/utils.tsx
@@ -10,6 +10,7 @@ import { IconSpeechbubbleText } from 'hds-react';
 import { TFunction } from 'i18next';
 import isEmpty from 'lodash/isEmpty';
 import React from 'react';
+import { matchPath } from 'react-router';
 
 import { DATE_TYPES } from '../../constants';
 import { Meta, QueryEventListArgs } from '../../generated/graphql';
@@ -26,6 +27,7 @@ import { Language } from '../../types';
 import buildQueryFromObject from '../../util/buildQueryFromObject';
 import { formatDate } from '../../util/dateUtils';
 import getUrlParamAsArray from '../../util/getUrlParamAsArray';
+import { ROUTES } from '../app/routes/constants';
 import { EVENT_TYPE_TO_ID, EventType } from '../event/types';
 import {
   COURSE_CATEGORIES,
@@ -443,4 +445,11 @@ export const getSearchQuery = (filters: Filters): string => {
   }
 
   return buildQueryFromObject(newFilters);
+};
+
+export const getEventTypeFromRouteUrl = (url: string): EventType => {
+  if (matchPath(url, { path: ROUTES.COURSES, exact: true, strict: false })) {
+    return 'course';
+  }
+  return 'event';
 };

--- a/src/domain/eventSearch/utils.tsx
+++ b/src/domain/eventSearch/utils.tsx
@@ -12,8 +12,8 @@ import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import { matchPath } from 'react-router';
 
+import { Meta, QueryEventListArgs } from '../../../src/generated/graphql';
 import { DATE_TYPES } from '../../constants';
-import { Meta, QueryEventListArgs } from '../../generated/graphql';
 import IconCultureAndArts from '../../icons/IconCultureAndArts';
 import IconDance from '../../icons/IconDance';
 import IconFood from '../../icons/IconFood';
@@ -447,9 +447,35 @@ export const getSearchQuery = (filters: Filters): string => {
   return buildQueryFromObject(newFilters);
 };
 
-export const getEventTypeFromRouteUrl = (url: string): EventType => {
-  if (matchPath(url, { path: ROUTES.COURSES, exact: true, strict: false })) {
-    return 'course';
+export const getEventTypeFromRouteUrl = (
+  url: string,
+  locale: Language
+): EventType | undefined => {
+  let eventType = 'event';
+  const routeToEventType = {
+    [`/${locale}${ROUTES.EVENTS}`]: 'event',
+    [`/${locale}${ROUTES.COURSES}`]: 'course',
+  };
+  if (!url) {
+    return undefined;
   }
-  return 'event';
+  try {
+    for (const route in routeToEventType) {
+      if (
+        matchPath(new URL(url).pathname, {
+          path: route,
+          exact: true,
+          strict: true,
+        })
+      ) {
+        eventType = routeToEventType[route];
+        break;
+      }
+    }
+  } catch (e) {
+    // Safe fallback for invalid URL.
+    return undefined;
+  }
+
+  return eventType as EventType;
 };

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -64,7 +64,6 @@ export type CollectionDetails = {
   description?: Maybe<LocalizedObject>,
   draftTitle?: Maybe<Scalars['String']>,
   eventListQuery?: Maybe<LocalizedObject>,
-  courseListQuery?: Maybe<LocalizedObject>,
   eventListTitle?: Maybe<LocalizedObject>,
   expireAt?: Maybe<Scalars['String']>,
   expired?: Maybe<Scalars['Boolean']>,


### PR DESCRIPTION
TH-1138.

NOTE: The code does not work yet. It needs LinkedEvents v2 and event type work done before it can be continued. It also needs changes from proxy https://github.com/City-of-Helsinki/events-helsinki-api-proxy/pull/64 and cms City-of-Helsinki/events-helsinki-cms#23
