### PR TITLE
Changed course page providers link text.

### DIFF
--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -57,7 +57,7 @@
       "buttonCopyLink": "Copy link address",
       "messageLinkCopySuccess": "Link copied into clipboard"
     },
-    "srOnly" : {
+    "srOnly": {
       "opensInANewTab": "Opens in a new tab"
     },
     "yearsShort": "y",
@@ -199,13 +199,18 @@
       "title": "Similar events"
     }
   },
+  "course": {
+    "info":{
+      "linkSearchByPublisher": "See other hobby courses by publisher"
+    }
+  },
   "eventSearch": {
     "ariaLiveLoading": "Searching for events",
     "ariaLiveSearchReady": "{{count}} search results",
     "buttonClearFilters": "Clear filters",
     "buttonLoadMore": "Show more events ({{count}})",
     "errorLoadMore": "Failed to load events",
-   "searchNotification": {
+    "searchNotification": {
       "noResultsTitle": "Sorry, no search results were found for the search criteria you selected.",
       "noResultsText": "No search results were found for the search criteria you selected. Try to change search terms or change to hobby search.",
       "fewResultsTitle": "Your search terms returned only a few results.",
@@ -363,7 +368,7 @@
     "searchCategories": "Browse Categories",
     "searchEvents": "Find something to do"
   },
-  "meta":{
+  "meta": {
     "events": {
       "description": "Tapahtumat.hel.fi’s event search. Concerts, gigs, theatre performances, exhibitions, culture, activities and other events in Helsinki."
     },

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -199,6 +199,11 @@
     },
     "title": "Ladataan tapahtumaa..."
   },
+  "course": {
+    "info":{
+      "linkSearchByPublisher": "Katso julkaisijan muut harrastuskurssit"
+    }
+  },
   "eventSearch": {
     "ariaLiveLoading": "Haetaan tapahtumia",
     "ariaLiveSearchReady": "{{count}} hakutulosta",

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -57,7 +57,7 @@
       "buttonCopyLink": "Kopiera länk adress",
       "messageLinkCopySuccess": "Länk kopierad till urklipp"
     },
-    "srOnly" : {
+    "srOnly": {
       "opensInANewTab": "Öppnas i en ny flik"
     },
     "yearsShort": "år",
@@ -198,6 +198,11 @@
       "title": "Liknande evenemang"
     },
     "title": "Laddar evenemang..."
+  },
+  "course": {
+    "info":{
+      "linkSearchByPublisher": "Se utgivarens övriga hobby kurser"
+    }
   },
   "eventSearch": {
     "ariaLiveLoading": "Söker efter evenemang",
@@ -363,7 +368,7 @@
     "searchCategories": "Bläddra i kategorier",
     "searchEvents": "Sök saker att göra"
   },
-  "meta":{
+  "meta": {
     "events": {
       "description": "Evenemangssökning på tapahtumat.hel.fi. Konserter, spelningar, teaterföreställningar, utställningar, kultur, aktiviteter och andra evenemang i Helsingfors."
     },

--- a/src/domain/event/eventInfo/OrganizationInfo.tsx
+++ b/src/domain/event/eventInfo/OrganizationInfo.tsx
@@ -53,7 +53,7 @@ const OrganizationInfo: React.FC<Props> = ({ event, eventType }) => {
               <>
                 <div>{organizationName}</div>
                 <Link to={getSearchLink()}>
-                  {t('event.info.linkSearchByPublisher')}
+                  {t(`${eventType}.info.linkSearchByPublisher`)}
                 </Link>
               </>
             )}

--- a/src/domain/event/eventInfo/__tests__/EventInfo.test.tsx
+++ b/src/domain/event/eventInfo/__tests__/EventInfo.test.tsx
@@ -21,6 +21,7 @@ import {
   userEvent,
   waitFor,
 } from '../../../../test/testUtils';
+import { EventType } from '../../types';
 import EventInfo from '../EventInfo';
 configure({ defaultHidden: true });
 
@@ -348,4 +349,18 @@ it('should hide audience age info on single event page', async () => {
   await waitFor(() => {
     expect(screen.queryByText(/Ikäryhmä/i)).not.toBeInTheDocument();
   });
+});
+
+describe('OrganizationInfo', () => {
+  it.each<[EventType, string]>([
+    ['event', 'Katso julkaisijan muut tapahtumat'],
+    ['course', 'Katso julkaisijan muut harrastuskurssit'],
+  ])(
+    'should show event type related providers link text in events info',
+    async (eventType, linkText) => {
+      render(<EventInfo event={event} eventType={eventType} />, { mocks });
+      await actWait();
+      expect(screen.queryByText(linkText)).toBeInTheDocument();
+    }
+  );
 });


### PR DESCRIPTION
TH-1140 To guide the user better, the course page publisher search link text is changed to something that describes that next query will be about courses.

NOTE: This is a self made not requested improvement.