### PR TITLE
Translation changes to navigation links

### DIFF
--- a/src/common/translation/i18n/en.json
+++ b/src/common/translation/i18n/en.json
@@ -201,7 +201,7 @@
   },
   "course": {
     "info":{
-      "linkSearchByPublisher": "See other hobby courses by publisher"
+      "linkSearchByPublisher": "See other hobbies by publisher"
     }
   },
   "eventSearch": {

--- a/src/common/translation/i18n/fi.json
+++ b/src/common/translation/i18n/fi.json
@@ -201,7 +201,7 @@
   },
   "course": {
     "info":{
-      "linkSearchByPublisher": "Katso julkaisijan muut harrastuskurssit"
+      "linkSearchByPublisher": "Katso julkaisijan muut harrastukset"
     }
   },
   "eventSearch": {

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -201,7 +201,7 @@
   },
   "course": {
     "info":{
-      "linkSearchByPublisher": "Se utgivarens övriga hobby kurser"
+      "linkSearchByPublisher": "Se utgivarens övriga hobbyer"
     }
   },
   "eventSearch": {

--- a/src/common/translation/i18n/sv.json
+++ b/src/common/translation/i18n/sv.json
@@ -273,7 +273,7 @@
     "linkFeedback": "Ge respons",
     "linkFeedbackUrl": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback/",
     "searchCollections": "Vi rekommenderar",
-    "searchEvents": "Evenemangen",
+    "searchEvents": "Evenemang",
     "searchHobbies": "Hobbyer",
     "titleEventsCategories": "Populära evenemangskategorier",
     "titleCoursesCategories": "Populära hobbykategorier",
@@ -291,7 +291,7 @@
       "sv": "På svenska"
     },
     "searchCollections": "Vi rekommenderar",
-    "searchEvents": "Evenemangen",
+    "searchEvents": "Evenemang",
     "searchHobbies": "Hobbyer"
   },
   "home": {

--- a/src/domain/event/eventInfo/__tests__/EventInfo.test.tsx
+++ b/src/domain/event/eventInfo/__tests__/EventInfo.test.tsx
@@ -354,7 +354,7 @@ it('should hide audience age info on single event page', async () => {
 describe('OrganizationInfo', () => {
   it.each<[EventType, string]>([
     ['event', 'Katso julkaisijan muut tapahtumat'],
-    ['course', 'Katso julkaisijan muut harrastuskurssit'],
+    ['course', 'Katso julkaisijan muut harrastukset'],
   ])(
     'should show event type related providers link text in events info',
     async (eventType, linkText) => {


### PR DESCRIPTION
TH-1140. A trivial provider link text change
TH-1121. "Evenemangen" -> "Evenemang"