### PR TITLE
fix: lined the buttons of the cards of the curated events

### DIFF
--- a/src/domain/event/eventCard/largeEventCard.module.scss
+++ b/src/domain/event/eventCard/largeEventCard.module.scss
@@ -115,6 +115,7 @@
       order: 7;
       display: flex;
       flex-wrap: wrap;
+      margin-top: auto;
 
       @include respond_above(sm) {
         justify-content: flex-end;


### PR DESCRIPTION
TH-1193 
![image](https://user-images.githubusercontent.com/389204/149318880-ec81b369-6a8a-4597-90f1-861601715964.png)
