### PR TITLE
TH-1199 | Replace self hosted Matomo with Digia Iiris Matomo

### DIFF
--- a/.env
+++ b/.env
@@ -9,8 +9,8 @@ REACT_APP_LINKED_EVENTS_URL=https://api.hel.fi/linkedevents/v1
 REACT_APP_IMAGE_PROXY_URL=https://images.weserv.nl/?w=1024&url=
 REACT_APP_GENERATE_SITEMAP=false
 
-REACT_APP_MATOMO_URL_BASE=https://analytics.hel.ninja/
-REACT_APP_MATOMO_SITE_ID=64
+REACT_APP_MATOMO_URL_BASE=//webanalytics.digiaiiris.com/js/
+REACT_APP_MATOMO_SITE_ID=708
 REACT_APP_MATOMO_ENABLED=false
 
 REACT_APP_GTM_AUTH=

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -40,8 +40,8 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_LINKED_EVENTS_URL: 'https://api.hel.fi/linkedevents/v1'
           DOCKER_BUILD_ARG_REACT_APP_IMAGE_PROXY_URL: 'https://images.weserv.nl/?w=1024&url='
           DOCKER_BUILD_ARG_REACT_APP_GENERATE_SITEMAP: 'true'
-          DOCKER_BUILD_ARG_REACT_APP_MATOMO_URL_BASE: 'https://analytics.hel.ninja/'
-          DOCKER_BUILD_ARG_REACT_APP_MATOMO_SITE_ID: 64
+          DOCKER_BUILD_ARG_REACT_APP_MATOMO_URL_BASE: '//webanalytics.digiaiiris.com/js/'
+          DOCKER_BUILD_ARG_REACT_APP_MATOMO_SITE_ID: 708
           DOCKER_BUILD_ARG_REACT_APP_MATOMO_ENABLED: 'true'
           DOCKER_BUILD_ARG_REACT_APP_GTM_AUTH: ${{ secrets.GH_PRODUCTION_GTM_AUTH }}
           DOCKER_BUILD_ARG_REACT_APP_GTM_ID: ${{ secrets.GH_PRODUCTION_GTM_ID }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -43,8 +43,8 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_LINKED_EVENTS_URL: 'https://api.hel.fi/linkedevents/v1'
           DOCKER_BUILD_ARG_REACT_APP_IMAGE_PROXY_URL: 'https://images.weserv.nl/?w=1024&url='
           DOCKER_BUILD_ARG_REACT_APP_GENERATE_SITEMAP: 'false'
-          DOCKER_BUILD_ARG_REACT_APP_MATOMO_URL_BASE: 'https://analytics.hel.ninja/'
-          DOCKER_BUILD_ARG_REACT_APP_MATOMO_SITE_ID: 64
+          DOCKER_BUILD_ARG_REACT_APP_MATOMO_URL_BASE: '//webanalytics.digiaiiris.com/js/'
+          DOCKER_BUILD_ARG_REACT_APP_MATOMO_SITE_ID: 708
           DOCKER_BUILD_ARG_REACT_APP_MATOMO_ENABLED: 'false'
           # Feature flags
           DOCKER_BUILD_ARG_REACT_APP_SHOW_SIMILAR_EVENTS: 'false'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -46,8 +46,8 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_LINKED_EVENTS_URL: 'https://api.hel.fi/linkedevents/v1'
           DOCKER_BUILD_ARG_REACT_APP_IMAGE_PROXY_URL: 'https://images.weserv.nl/?w=1024&url='
           DOCKER_BUILD_ARG_REACT_APP_GENERATE_SITEMAP: 'false'
-          DOCKER_BUILD_ARG_REACT_APP_MATOMO_URL_BASE: 'https://analytics.hel.ninja/'
-          DOCKER_BUILD_ARG_REACT_APP_MATOMO_SITE_ID: 64
+          DOCKER_BUILD_ARG_REACT_APP_MATOMO_URL_BASE: '//webanalytics.digiaiiris.com/js/'
+          DOCKER_BUILD_ARG_REACT_APP_MATOMO_SITE_ID: 708
           DOCKER_BUILD_ARG_REACT_APP_MATOMO_ENABLED: 'false'
           DOCKER_BUILD_ARG_REACT_APP_GTM_AUTH: ${{ secrets.GH_QA_GTM_AUTH }}
           DOCKER_BUILD_ARG_REACT_APP_GTM_ID: ${{ secrets.GH_QA_GTM_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/City-of-Helsinki/events-helsinki-ui/compare/v0.9.0...v0.§0.0) (2022-03-28)
+
 ### Changed
 
 - Analytics from self hosted Matomo into Digia Iiris Matomo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [Unreleased]
+
+### Changed
+
+- Analytics from self hosted Matomo into Digia Iiris Matomo
+
 ## [0.9.0](https://github.com/City-of-Helsinki/events-helsinki-ui/compare/v0.8.0...v0.9.0) (2022-01-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "events-helsinki-ui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.4.0-rc.6",

--- a/src/domain/app/BrowserApp.tsx
+++ b/src/domain/app/BrowserApp.tsx
@@ -11,10 +11,13 @@ import { BrowserRouter } from 'react-router-dom';
 import apolloClient from './apollo/apolloClient';
 import App from './App';
 
+const matomoUrlBase = process.env.REACT_APP_MATOMO_URL_BASE as string;
 const instance = createInstance({
   disabled: process.env.REACT_APP_MATOMO_ENABLED !== 'true',
-  urlBase: process.env.REACT_APP_MATOMO_URL_BASE as string,
+  urlBase: matomoUrlBase,
   siteId: Number(process.env.REACT_APP_MATOMO_SITE_ID),
+  trackerUrl: `${matomoUrlBase}tracker.php`,
+  srcUrl: `${matomoUrlBase}piwik.min.js`,
 });
 
 const BrowserApp: React.FC = () => {


### PR DESCRIPTION
## Description :sparkles:

Changes from self hosted Matomo into Digia Iiris Matomo.

I tested this configuration locally. Aiski verified that Matomo received data with these configs.

Contains documentation for release 0.10.0.

## Issues :bug:

### Closes :no_good_woman:

**[TH-1199](https://helsinkisolutionoffice.atlassian.net/browse/TH-1199):**
