### PR TITLE
feat: sort the events in the collection by a start time

### DIFF
--- a/src/domain/collection/__tests__/CollectionPageContainer.test.tsx
+++ b/src/domain/collection/__tests__/CollectionPageContainer.test.tsx
@@ -56,7 +56,7 @@ const getMocks = (
       eventType: [EventTypeId.General],
       include: ['location'],
       pageSize: 10,
-      sort: 'end_time',
+      sort: 'start_time',
       start: 'now',
     },
     eventsByIds,

--- a/src/domain/collection/curatedEvents/__tests__/CuratedEvents.test.tsx
+++ b/src/domain/collection/curatedEvents/__tests__/CuratedEvents.test.tsx
@@ -183,7 +183,7 @@ const getMocks = (
     eventType: [EventTypeId.General],
     include: ['location'],
     pageSize: 10,
-    sort: 'end_time',
+    sort: 'start_time',
     page: undefined,
     start: 'now',
   };

--- a/src/domain/collection/curatedEvents/usePaginatedEventsByIdsQuery.tsx
+++ b/src/domain/collection/curatedEvents/usePaginatedEventsByIdsQuery.tsx
@@ -39,7 +39,7 @@ const usePaginatedEventsByIdsQuery = (
       eventType: [EventTypeId.General],
       include: ['location'],
       pageSize: PAGE_SIZE,
-      sort: EVENT_SORT_OPTIONS.END_TIME,
+      sort: EVENT_SORT_OPTIONS.START_TIME,
       start: 'now',
     },
     ssr: false,


### PR DESCRIPTION
TH-1203. Instead of sorting the events by an end time, they should now be sorted by a start time. This is opposite for what was decided earlier in TH-1029 and TH-1183. When the events are ordered b a start time, the long lasting events always fills the first pages, but when they are ordered by the end time, the result set looks weird and it's hard to see that long lasting events starts already.