### PR TITLE
feat: sort the events in every listing by a start time

### DIFF
--- a/browser-tests/datasources/eventDataSource.ts
+++ b/browser-tests/datasources/eventDataSource.ts
@@ -22,7 +22,7 @@ export const getEvents = async (
     include: ['keywords', 'location'],
     language: SUPPORT_LANGUAGES.FI,
     pageSize: count,
-    sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+    sortOrder: EVENT_SORT_OPTIONS.START_TIME,
     superEventType: ['umbrella', 'none'],
   });
   const {

--- a/src/domain/collection/curatedEvents/__tests__/CuratedEvents.test.tsx
+++ b/src/domain/collection/curatedEvents/__tests__/CuratedEvents.test.tsx
@@ -198,13 +198,13 @@ const getMocks = (
   if (page && page < maxPage) {
     meta.next = `https://api.hel.fi/linkedevents/v1/event/?ids=${ids.toString()}&page_size=10&page=${
       page + 1
-    }&sort=end_time&include=location`;
+    }&sort=start_time&include=location`;
   }
   if (page > 1) {
     variables.page = page;
     meta.previous = `https://api.hel.fi/linkedevents/v1/event/?ids=${ids.toString()}&page_size=10&page=${
       page - 1
-    }&sort=end_time&include=location`;
+    }&sort=start_time&include=location`;
   }
   return [
     {

--- a/src/domain/collection/eventList/EventList.tsx
+++ b/src/domain/collection/eventList/EventList.tsx
@@ -38,7 +38,7 @@ const EventList: React.FC<Props> = ({ collection }) => {
       language: locale,
       pageSize: PAGE_SIZE,
       params: searchParams,
-      sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+      sortOrder: EVENT_SORT_OPTIONS.START_TIME,
       superEventType: ['umbrella', 'none'],
     });
   }, [eventListQuery, locale]);

--- a/src/domain/event/queryUtils.ts
+++ b/src/domain/event/queryUtils.ts
@@ -41,7 +41,7 @@ const useSimilarEventsQueryVariables = (event: EventFields) => {
       language: locale,
       pageSize: PAGE_SIZE,
       params: searchParams,
-      sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+      sortOrder: EVENT_SORT_OPTIONS.START_TIME,
       superEventType: ['umbrella', 'none'],
     });
   }, [eventSearch, locale, search]);

--- a/src/domain/eventSearch/SearchPage.tsx
+++ b/src/domain/eventSearch/SearchPage.tsx
@@ -47,7 +47,7 @@ const SearchPage: React.FC<{
       pageSize: PAGE_SIZE,
       params: searchParams,
       place: params.place,
-      sortOrder: EVENT_SORT_OPTIONS.END_TIME,
+      sortOrder: EVENT_SORT_OPTIONS.START_TIME,
       superEventType: ['umbrella', 'none'],
     });
     return variables;

--- a/src/domain/eventSearch/__tests__/EventSearchPageContainer.test.tsx
+++ b/src/domain/eventSearch/__tests__/EventSearchPageContainer.test.tsx
@@ -32,7 +32,7 @@ const meta: Meta = {
   count: 20,
   next:
     // eslint-disable-next-line max-len
-    'https://api.hel.fi/linkedevents/v1/event/?division=kunta%3Ahelsinki&include=keywords%2Clocation&language=fi&page=2&page_size=10&sort=end_time&start=2020-08-12T17&super_event_type=umbrella%2Cnone&text=jazz',
+    'https://api.hel.fi/linkedevents/v1/event/?division=kunta%3Ahelsinki&include=keywords%2Clocation&language=fi&page=2&page_size=10&sort=start_time&start=2020-08-12T17&super_event_type=umbrella%2Cnone&text=jazz',
   previous: null,
   __typename: 'Meta',
 };

--- a/src/test/apollo-mocks/eventListMocks.ts
+++ b/src/test/apollo-mocks/eventListMocks.ts
@@ -20,7 +20,7 @@ export const baseVariables = {
   location: [],
   pageSize: 10,
   publisher: null,
-  sort: 'end_time',
+  sort: 'start_time',
   start: 'now',
   startsAfter: undefined,
   superEventType: ['umbrella', 'none'],


### PR DESCRIPTION
TH-1203 TH-1204. In #341 the curated events were changed to be sorted by start time. This pull request sorts the rest / every event list by start time.